### PR TITLE
refactor: extract shared bash helpers into lib/common.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: bash syntax (3.2-safe parse)
         run: |
-          for f in install.sh uninstall.sh scripts/*.sh config/zshrc.block.sh; do
+          for f in install.sh uninstall.sh lib/common.sh scripts/*.sh config/zshrc.block.sh; do
             bash -n "$f"
           done
       - name: shellcheck
-        run: shellcheck -x -S warning -e SC2154 install.sh uninstall.sh scripts/*.sh
+        run: shellcheck -x -S warning -e SC2154 install.sh uninstall.sh lib/common.sh scripts/*.sh
 
   lint-linux:
     name: linux shellcheck + syntax

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,12 @@ PRs that add non-core tools to the base will be asked to move them to
   `mapfile`, `${x,,}`, etc. (`bash -n` must pass under `/bin/bash`).
 - **Idempotent & non-destructive** — re-running must be safe; never clobber a
   user's existing config (fill empty values, use the managed-block markers).
-- **shellcheck clean** — `shellcheck -x -S warning -e SC2154 install.sh uninstall.sh scripts/*.sh`.
+- **shellcheck clean** — `shellcheck -x -S warning -e SC2154 install.sh uninstall.sh lib/common.sh scripts/*.sh`.
+- **Shared helpers live in `lib/common.sh`** — the OS-agnostic bash helpers
+  (colors, `run`, `ask`/`confirm`, `inject_block`, …) are shared by the macOS
+  (`scripts/lib.sh`) and Linux (`linux/scripts/lib.sh`) kits, which source it and
+  add only their OS-specific bits. Fix shared behavior in `lib/common.sh` so it
+  can't land in only one tree.
 - **Preview first** — verify with `./install.sh --dry-run` (and `--dry-run` for
   uninstall).
 - **CI must pass** — lint + macOS dry-run + a real install→uninstall run.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# common.sh — OS-agnostic shared helpers for lazy-starter-kit.
+#
+# Sourced by scripts/lib.sh (macOS) and linux/scripts/lib.sh, each of which adds
+# its own OS-specific bits. Kept in ONE place so a fix can't accidentally land in
+# only one tree (that has caused real one-sided bugs in the past).
+#
+# bash 3.2 compatible (macOS ships bash 3.2); expects a `set -euo pipefail` caller.
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+if [[ -t 1 ]]; then
+  _C_RESET=$'\033[0m'; _C_DIM=$'\033[2m'; _C_RED=$'\033[31m'
+  _C_GREEN=$'\033[32m'; _C_YELLOW=$'\033[33m'; _C_BLUE=$'\033[34m'; _C_BOLD=$'\033[1m'
+else
+  _C_RESET=''; _C_DIM=''; _C_RED=''; _C_GREEN=''; _C_YELLOW=''; _C_BLUE=''; _C_BOLD=''
+fi
+
+step()  { printf '\n%s==>%s %s%s%s\n' "$_C_BLUE$_C_BOLD" "$_C_RESET" "$_C_BOLD" "$*" "$_C_RESET"; }
+info()  { printf '%s  •%s %s\n' "$_C_DIM" "$_C_RESET" "$*"; }
+ok()    { printf '%s  ✓%s %s\n' "$_C_GREEN" "$_C_RESET" "$*"; }
+warn()  { printf '%s  !%s %s\n' "$_C_YELLOW" "$_C_RESET" "$*" >&2; }
+err()   { printf '%s  ✗%s %s\n' "$_C_RED" "$_C_RESET" "$*" >&2; }
+die()   { err "$*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Environment flags (exported by install.sh)
+# ---------------------------------------------------------------------------
+: "${DRY_RUN:=0}"    # 1 = print actions, do not execute
+: "${ASSUME_YES:=0}" # 1 = never prompt, take defaults
+
+# run CMD...  — execute, or just print under DRY_RUN
+run() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf '%s  [dry-run]%s %s\n' "$_C_DIM" "$_C_RESET" "$*"
+    return 0
+  fi
+  "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Predicates
+# ---------------------------------------------------------------------------
+have()        { command -v "$1" >/dev/null 2>&1; }
+is_tty()      { [[ -t 0 ]]; }
+
+# load mise shims into PATH for the current process
+load_mise() {
+  have mise && eval "$(mise activate bash --shims)" 2>/dev/null || true
+  export PATH="$HOME/.local/share/mise/shims:$PATH"
+}
+
+# ---------------------------------------------------------------------------
+# Prompts
+# ---------------------------------------------------------------------------
+# ask "Question?" "default"  -> echoes the answer (default under ASSUME_YES / no tty)
+ask() {
+  local q="$1" def="${2:-}"
+  if [[ "$ASSUME_YES" == "1" ]] || ! is_tty; then echo "$def"; return; fi
+  local ans; read -r -p "$q " ans || true
+  echo "${ans:-$def}"
+}
+
+# confirm "Question?"  -> yes(0)/no(1).
+#   --yes (ASSUME_YES): always yes.  non-interactive without --yes: decline (skip optional/heavy action).
+confirm() {
+  local q="$1"
+  [[ "$ASSUME_YES" == "1" ]] && return 0
+  is_tty || return 1
+  local ans; read -r -p "$q [Y/n] " ans || true
+  [[ -z "$ans" || "$ans" =~ ^[Yy] ]]
+}
+
+# ---------------------------------------------------------------------------
+# Managed-block injection — idempotent insert/replace between markers
+# inject_block <file> <tag> <<<"content"   (content read from stdin)
+# Re-running replaces the block; never duplicates.
+# ---------------------------------------------------------------------------
+inject_block() {
+  local file="$1" tag="$2"
+  local begin="# >>> ${tag} >>>"
+  local end="# <<< ${tag} <<<"
+  local content; content="$(cat)"
+
+  # Refuse to touch a file whose markers are unbalanced (crashed run / hand-edit):
+  # rewriting would drop everything between the lone marker and EOF — the user's
+  # own config. grep -qxF = whole-line fixed match, mirroring awk's $0==b/$0==e.
+  if [[ -f "$file" ]]; then
+    local has_begin=0 has_end=0
+    grep -qxF "$begin" "$file" && has_begin=1
+    grep -qxF "$end"   "$file" && has_end=1
+    if [[ "$has_begin" != "$has_end" ]]; then
+      warn "${file/#$HOME/~} has an unmatched lazy-starter-kit '$tag' marker; refusing to modify it. Fix or delete the stray marker line by hand."
+      return 0
+    fi
+  fi
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    if [[ -f "$file" ]] && grep -qF "$begin" "$file"; then
+      info "[dry-run] would update '$tag' block in ${file/#$HOME/~}"
+    else
+      info "[dry-run] would add '$tag' block to ${file/#$HOME/~}"
+    fi
+    return 0
+  fi
+
+  run mkdir -p "$(dirname "$file")"
+  [[ -f "$file" ]] || : > "$file"
+
+  # one-time safety backup before the first rewrite of a non-empty user file
+  local bak="$file.lazy-starter-kit.bak"
+  if [[ -s "$file" && ! -e "$bak" ]]; then
+    cp "$file" "$bak"
+    info "backed up ${file/#$HOME/~} -> ${bak/#$HOME/~} (first change)"
+  fi
+
+  local tmp; tmp="$(mktemp)"
+  # copy everything outside the existing block
+  awk -v b="$begin" -v e="$end" '
+    $0==b {skip=1} skip && $0==e {skip=0; next} !skip {print}
+  ' "$file" > "$tmp"
+
+  # trim a single trailing blank line for tidiness, then append the block
+  {
+    cat "$tmp"
+    printf '%s\n%s\n%s\n' "$begin" "$content" "$end"
+  } > "$file"
+  rm -f "$tmp"
+  ok "wrote '$tag' block -> ${file/#$HOME/~}"
+}
+
+# remove_block <file> <tag>  — delete a managed block (markers + content). Idempotent.
+remove_block() {
+  local file="$1" tag="$2"
+  local begin="# >>> ${tag} >>>"
+  local end="# <<< ${tag} <<<"
+  [[ -f "$file" ]] || { info "no ${file/#$HOME/~} (skip '$tag')"; return 0; }
+
+  # Refuse on unbalanced markers (see inject_block): a lone begin marker would
+  # make awk skip to EOF and delete the user's own config below it.
+  local has_begin=0 has_end=0
+  grep -qxF "$begin" "$file" && has_begin=1
+  grep -qxF "$end"   "$file" && has_end=1
+  if [[ "$has_begin" != "$has_end" ]]; then
+    warn "${file/#$HOME/~} has an unmatched lazy-starter-kit '$tag' marker; refusing to modify it. Fix or delete the stray marker line by hand."
+    return 0
+  fi
+  [[ "$has_begin" == 1 ]] || { info "no '$tag' block in ${file/#$HOME/~}"; return 0; }
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    info "[dry-run] would remove '$tag' block from ${file/#$HOME/~}"
+    return 0
+  fi
+
+  # one-time safety backup before the first rewrite of a non-empty user file
+  local bak="$file.lazy-starter-kit.bak"
+  if [[ -s "$file" && ! -e "$bak" ]]; then
+    cp "$file" "$bak"
+    info "backed up ${file/#$HOME/~} -> ${bak/#$HOME/~} (first change)"
+  fi
+
+  local tmp; tmp="$(mktemp)"
+  awk -v b="$begin" -v e="$end" '
+    $0==b {skip=1} skip && $0==e {skip=0; next} !skip {print}
+  ' "$file" > "$tmp"
+  mv "$tmp" "$file"
+  ok "removed '$tag' block from ${file/#$HOME/~}"
+}

--- a/linux/scripts/lib.sh
+++ b/linux/scripts/lib.sh
@@ -1,44 +1,19 @@
 #!/usr/bin/env bash
-# lib.sh — shared helpers for lazy-starter-kit
+# lib.sh — Linux helpers for lazy-starter-kit.
 # sourced by install.sh and every scripts/NN-*.sh step.
+#
+# OS-agnostic helpers (colors, run, ask/confirm, inject_block, …) live in
+# lib/common.sh so the macOS and Linux kits share ONE copy. This file adds only
+# the Linux-specific bits below. Resolve our own dir via BASH_SOURCE so sourcing
+# works regardless of $ROOT / cwd. It must come first: the SUDO/PM setup and
+# pm_* helpers below rely on have()/confirm() from common.sh.
+_KIT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$_KIT_LIB_DIR/../../lib/common.sh"
 
 # ---------------------------------------------------------------------------
-# Output helpers
+# Linux-specific predicate
 # ---------------------------------------------------------------------------
-if [[ -t 1 ]]; then
-  _C_RESET=$'\033[0m'; _C_DIM=$'\033[2m'; _C_RED=$'\033[31m'
-  _C_GREEN=$'\033[32m'; _C_YELLOW=$'\033[33m'; _C_BLUE=$'\033[34m'; _C_BOLD=$'\033[1m'
-else
-  _C_RESET=''; _C_DIM=''; _C_RED=''; _C_GREEN=''; _C_YELLOW=''; _C_BLUE=''; _C_BOLD=''
-fi
-
-step()  { printf '\n%s==>%s %s%s%s\n' "$_C_BLUE$_C_BOLD" "$_C_RESET" "$_C_BOLD" "$*" "$_C_RESET"; }
-info()  { printf '%s  •%s %s\n' "$_C_DIM" "$_C_RESET" "$*"; }
-ok()    { printf '%s  ✓%s %s\n' "$_C_GREEN" "$_C_RESET" "$*"; }
-warn()  { printf '%s  !%s %s\n' "$_C_YELLOW" "$_C_RESET" "$*" >&2; }
-err()   { printf '%s  ✗%s %s\n' "$_C_RED" "$_C_RESET" "$*" >&2; }
-die()   { err "$*"; exit 1; }
-
-# ---------------------------------------------------------------------------
-# Environment flags (exported by install.sh)
-# ---------------------------------------------------------------------------
-: "${DRY_RUN:=0}"    # 1 = print actions, do not execute
-: "${ASSUME_YES:=0}" # 1 = never prompt, take defaults
-
-# run CMD...  — execute, or just print under DRY_RUN
-run() {
-  if [[ "$DRY_RUN" == "1" ]]; then
-    printf '%s  [dry-run]%s %s\n' "$_C_DIM" "$_C_RESET" "$*"
-    return 0
-  fi
-  "$@"
-}
-
-# ---------------------------------------------------------------------------
-# Predicates
-# ---------------------------------------------------------------------------
-have()        { command -v "$1" >/dev/null 2>&1; }
-is_tty()      { [[ -t 0 ]]; }
 is_linux()    { [[ "$(uname -s)" == "Linux" ]]; }
 
 # ---------------------------------------------------------------------------
@@ -156,126 +131,4 @@ load_local_bins() {
   export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.bun/bin:$PATH"
   [[ -d "$HOME/.local/share/mise/shims" ]] && export PATH="$HOME/.local/share/mise/shims:$PATH"
   return 0   # never fail under `set -e` (trailing test may be false)
-}
-
-# load mise shims into PATH for the current process
-load_mise() {
-  have mise && eval "$(mise activate bash --shims)" 2>/dev/null || true
-  export PATH="$HOME/.local/share/mise/shims:$PATH"
-}
-
-# ---------------------------------------------------------------------------
-# Prompts
-# ---------------------------------------------------------------------------
-# ask "Question?" "default"  -> echoes the answer (default under ASSUME_YES / no tty)
-ask() {
-  local q="$1" def="${2:-}"
-  if [[ "$ASSUME_YES" == "1" ]] || ! is_tty; then echo "$def"; return; fi
-  local ans; read -r -p "$q " ans || true
-  echo "${ans:-$def}"
-}
-
-# confirm "Question?"  -> yes(0)/no(1).
-#   --yes (ASSUME_YES): always yes.  non-interactive without --yes: decline.
-confirm() {
-  local q="$1"
-  [[ "$ASSUME_YES" == "1" ]] && return 0
-  is_tty || return 1
-  local ans; read -r -p "$q [Y/n] " ans || true
-  [[ -z "$ans" || "$ans" =~ ^[Yy] ]]
-}
-
-# ---------------------------------------------------------------------------
-# Managed-block injection — idempotent insert/replace between markers
-# inject_block <file> <tag> <<<"content"   (content read from stdin)
-# Re-running replaces the block; never duplicates.
-# ---------------------------------------------------------------------------
-inject_block() {
-  local file="$1" tag="$2"
-  local begin="# >>> ${tag} >>>"
-  local end="# <<< ${tag} <<<"
-  local content; content="$(cat)"
-
-  # Refuse to touch a file whose markers are unbalanced (crashed run / hand-edit):
-  # rewriting would drop everything between the lone marker and EOF — the user's
-  # own config. grep -qxF = whole-line fixed match, mirroring awk's $0==b/$0==e.
-  if [[ -f "$file" ]]; then
-    local has_begin=0 has_end=0
-    grep -qxF "$begin" "$file" && has_begin=1
-    grep -qxF "$end"   "$file" && has_end=1
-    if [[ "$has_begin" != "$has_end" ]]; then
-      warn "${file/#$HOME/~} has an unmatched lazy-starter-kit '$tag' marker; refusing to modify it. Fix or delete the stray marker line by hand."
-      return 0
-    fi
-  fi
-
-  if [[ "$DRY_RUN" == "1" ]]; then
-    if [[ -f "$file" ]] && grep -qF "$begin" "$file"; then
-      info "[dry-run] would update '$tag' block in ${file/#$HOME/~}"
-    else
-      info "[dry-run] would add '$tag' block to ${file/#$HOME/~}"
-    fi
-    return 0
-  fi
-
-  run mkdir -p "$(dirname "$file")"
-  [[ -f "$file" ]] || : > "$file"
-
-  # one-time safety backup before the first rewrite of a non-empty user file
-  local bak="$file.lazy-starter-kit.bak"
-  if [[ -s "$file" && ! -e "$bak" ]]; then
-    cp "$file" "$bak"
-    info "backed up ${file/#$HOME/~} -> ${bak/#$HOME/~} (first change)"
-  fi
-
-  local tmp; tmp="$(mktemp)"
-  # copy everything outside the existing block
-  awk -v b="$begin" -v e="$end" '
-    $0==b {skip=1} skip && $0==e {skip=0; next} !skip {print}
-  ' "$file" > "$tmp"
-
-  {
-    cat "$tmp"
-    printf '%s\n%s\n%s\n' "$begin" "$content" "$end"
-  } > "$file"
-  rm -f "$tmp"
-  ok "wrote '$tag' block -> ${file/#$HOME/~}"
-}
-
-# remove_block <file> <tag>  — delete a managed block (markers + content). Idempotent.
-remove_block() {
-  local file="$1" tag="$2"
-  local begin="# >>> ${tag} >>>"
-  local end="# <<< ${tag} <<<"
-  [[ -f "$file" ]] || { info "no ${file/#$HOME/~} (skip '$tag')"; return 0; }
-
-  # Refuse on unbalanced markers (see inject_block): a lone begin marker would
-  # make awk skip to EOF and delete the user's own config below it.
-  local has_begin=0 has_end=0
-  grep -qxF "$begin" "$file" && has_begin=1
-  grep -qxF "$end"   "$file" && has_end=1
-  if [[ "$has_begin" != "$has_end" ]]; then
-    warn "${file/#$HOME/~} has an unmatched lazy-starter-kit '$tag' marker; refusing to modify it. Fix or delete the stray marker line by hand."
-    return 0
-  fi
-  [[ "$has_begin" == 1 ]] || { info "no '$tag' block in ${file/#$HOME/~}"; return 0; }
-
-  if [[ "$DRY_RUN" == "1" ]]; then
-    info "[dry-run] would remove '$tag' block from ${file/#$HOME/~}"
-    return 0
-  fi
-
-  # one-time safety backup before the first rewrite of a non-empty user file
-  local bak="$file.lazy-starter-kit.bak"
-  if [[ -s "$file" && ! -e "$bak" ]]; then
-    cp "$file" "$bak"
-    info "backed up ${file/#$HOME/~} -> ${bak/#$HOME/~} (first change)"
-  fi
-
-  local tmp; tmp="$(mktemp)"
-  awk -v b="$begin" -v e="$end" '
-    $0==b {skip=1} skip && $0==e {skip=0; next} !skip {print}
-  ' "$file" > "$tmp"
-  mv "$tmp" "$file"
-  ok "removed '$tag' block from ${file/#$HOME/~}"
 }

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,44 +1,18 @@
 #!/usr/bin/env bash
-# lib.sh — shared helpers for lazy-starter-kit
+# lib.sh — macOS helpers for lazy-starter-kit.
 # sourced by install.sh and every scripts/NN-*.sh step.
+#
+# OS-agnostic helpers (colors, run, ask/confirm, inject_block, …) live in
+# lib/common.sh so the macOS and Linux kits share ONE copy. This file adds only
+# the macOS-specific bits below. Resolve our own dir via BASH_SOURCE so sourcing
+# works regardless of $ROOT / cwd.
+_KIT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$_KIT_LIB_DIR/../lib/common.sh"
 
 # ---------------------------------------------------------------------------
-# Output helpers
+# macOS-specific predicates
 # ---------------------------------------------------------------------------
-if [[ -t 1 ]]; then
-  _C_RESET=$'\033[0m'; _C_DIM=$'\033[2m'; _C_RED=$'\033[31m'
-  _C_GREEN=$'\033[32m'; _C_YELLOW=$'\033[33m'; _C_BLUE=$'\033[34m'; _C_BOLD=$'\033[1m'
-else
-  _C_RESET=''; _C_DIM=''; _C_RED=''; _C_GREEN=''; _C_YELLOW=''; _C_BLUE=''; _C_BOLD=''
-fi
-
-step()  { printf '\n%s==>%s %s%s%s\n' "$_C_BLUE$_C_BOLD" "$_C_RESET" "$_C_BOLD" "$*" "$_C_RESET"; }
-info()  { printf '%s  •%s %s\n' "$_C_DIM" "$_C_RESET" "$*"; }
-ok()    { printf '%s  ✓%s %s\n' "$_C_GREEN" "$_C_RESET" "$*"; }
-warn()  { printf '%s  !%s %s\n' "$_C_YELLOW" "$_C_RESET" "$*" >&2; }
-err()   { printf '%s  ✗%s %s\n' "$_C_RED" "$_C_RESET" "$*" >&2; }
-die()   { err "$*"; exit 1; }
-
-# ---------------------------------------------------------------------------
-# Environment flags (exported by install.sh)
-# ---------------------------------------------------------------------------
-: "${DRY_RUN:=0}"   # 1 = print actions, do not execute
-: "${ASSUME_YES:=0}" # 1 = never prompt, take defaults
-
-# run CMD...  — execute, or just print under DRY_RUN
-run() {
-  if [[ "$DRY_RUN" == "1" ]]; then
-    printf '%s  [dry-run]%s %s\n' "$_C_DIM" "$_C_RESET" "$*"
-    return 0
-  fi
-  "$@"
-}
-
-# ---------------------------------------------------------------------------
-# Predicates
-# ---------------------------------------------------------------------------
-have()        { command -v "$1" >/dev/null 2>&1; }
-is_tty()      { [[ -t 0 ]]; }
 is_macos()    { [[ "$(uname -s)" == "Darwin" ]]; }
 is_arm()      { [[ "$(uname -m)" == "arm64" ]]; }
 
@@ -53,124 +27,4 @@ brew_prefix() {
 load_brew() {
   local p; p="$(brew_prefix)"
   [[ -x "$p/bin/brew" ]] && eval "$("$p/bin/brew" shellenv)"
-}
-
-# load mise shims into PATH for the current process
-load_mise() {
-  have mise && eval "$(mise activate bash --shims)" 2>/dev/null || true
-  export PATH="$HOME/.local/share/mise/shims:$PATH"
-}
-
-# ask "Question?" "default"  -> echoes the answer (default under ASSUME_YES / no tty)
-ask() {
-  local q="$1" def="${2:-}"
-  if [[ "$ASSUME_YES" == "1" ]] || ! is_tty; then echo "$def"; return; fi
-  local ans; read -r -p "$q " ans || true
-  echo "${ans:-$def}"
-}
-
-# confirm "Question?"  -> yes(0)/no(1).
-#   --yes (ASSUME_YES): always yes.  non-interactive without --yes: decline (skip optional/heavy action).
-confirm() {
-  local q="$1"
-  [[ "$ASSUME_YES" == "1" ]] && return 0
-  is_tty || return 1
-  local ans; read -r -p "$q [Y/n] " ans || true
-  [[ -z "$ans" || "$ans" =~ ^[Yy] ]]
-}
-
-# ---------------------------------------------------------------------------
-# Managed-block injection — idempotent insert/replace between markers
-# inject_block <file> <tag> <<<"content"   (content read from stdin)
-# Re-running replaces the block; never duplicates.
-# ---------------------------------------------------------------------------
-inject_block() {
-  local file="$1" tag="$2"
-  local begin="# >>> ${tag} >>>"
-  local end="# <<< ${tag} <<<"
-  local content; content="$(cat)"
-
-  # Refuse to touch a file whose markers are unbalanced (crashed run / hand-edit):
-  # rewriting would drop everything between the lone marker and EOF — the user's
-  # own config. grep -qxF = whole-line fixed match, mirroring awk's $0==b/$0==e.
-  if [[ -f "$file" ]]; then
-    local has_begin=0 has_end=0
-    grep -qxF "$begin" "$file" && has_begin=1
-    grep -qxF "$end"   "$file" && has_end=1
-    if [[ "$has_begin" != "$has_end" ]]; then
-      warn "${file/#$HOME/~} has an unmatched lazy-starter-kit '$tag' marker; refusing to modify it. Fix or delete the stray marker line by hand."
-      return 0
-    fi
-  fi
-
-  if [[ "$DRY_RUN" == "1" ]]; then
-    if [[ -f "$file" ]] && grep -qF "$begin" "$file"; then
-      info "[dry-run] would update '$tag' block in ${file/#$HOME/~}"
-    else
-      info "[dry-run] would add '$tag' block to ${file/#$HOME/~}"
-    fi
-    return 0
-  fi
-
-  run mkdir -p "$(dirname "$file")"
-  [[ -f "$file" ]] || : > "$file"
-
-  # one-time safety backup before the first rewrite of a non-empty user file
-  local bak="$file.lazy-starter-kit.bak"
-  if [[ -s "$file" && ! -e "$bak" ]]; then
-    cp "$file" "$bak"
-    info "backed up ${file/#$HOME/~} -> ${bak/#$HOME/~} (first change)"
-  fi
-
-  local tmp; tmp="$(mktemp)"
-  # copy everything outside the existing block
-  awk -v b="$begin" -v e="$end" '
-    $0==b {skip=1} skip && $0==e {skip=0; next} !skip {print}
-  ' "$file" > "$tmp"
-
-  # trim a single trailing blank line for tidiness, then append the block
-  {
-    cat "$tmp"
-    printf '%s\n%s\n%s\n' "$begin" "$content" "$end"
-  } > "$file"
-  rm -f "$tmp"
-  ok "wrote '$tag' block -> ${file/#$HOME/~}"
-}
-
-# remove_block <file> <tag>  — delete a managed block (markers + content). Idempotent.
-remove_block() {
-  local file="$1" tag="$2"
-  local begin="# >>> ${tag} >>>"
-  local end="# <<< ${tag} <<<"
-  [[ -f "$file" ]] || { info "no ${file/#$HOME/~} (skip '$tag')"; return 0; }
-
-  # Refuse on unbalanced markers (see inject_block): a lone begin marker would
-  # make awk skip to EOF and delete the user's own config below it.
-  local has_begin=0 has_end=0
-  grep -qxF "$begin" "$file" && has_begin=1
-  grep -qxF "$end"   "$file" && has_end=1
-  if [[ "$has_begin" != "$has_end" ]]; then
-    warn "${file/#$HOME/~} has an unmatched lazy-starter-kit '$tag' marker; refusing to modify it. Fix or delete the stray marker line by hand."
-    return 0
-  fi
-  [[ "$has_begin" == 1 ]] || { info "no '$tag' block in ${file/#$HOME/~}"; return 0; }
-
-  if [[ "$DRY_RUN" == "1" ]]; then
-    info "[dry-run] would remove '$tag' block from ${file/#$HOME/~}"
-    return 0
-  fi
-
-  # one-time safety backup before the first rewrite of a non-empty user file
-  local bak="$file.lazy-starter-kit.bak"
-  if [[ -s "$file" && ! -e "$bak" ]]; then
-    cp "$file" "$bak"
-    info "backed up ${file/#$HOME/~} -> ${bak/#$HOME/~} (first change)"
-  fi
-
-  local tmp; tmp="$(mktemp)"
-  awk -v b="$begin" -v e="$end" '
-    $0==b {skip=1} skip && $0==e {skip=0; next} !skip {print}
-  ' "$file" > "$tmp"
-  mv "$tmp" "$file"
-  ok "removed '$tag' block from ${file/#$HOME/~}"
 }


### PR DESCRIPTION
## Motivation

`scripts/lib.sh` (macOS) and `linux/scripts/lib.sh` (Linux) carried byte-for-byte duplicates of the OS-agnostic bash helpers. Keeping the two copies in parity by hand has caused **real one-sided-fix bugs** — a hardening fix lands in one tree and the other silently drifts. This extracts the shared code into a single source of truth.

## The split

**New `lib/common.sh`** (everything the two libs shared verbatim):
- color setup + `step`/`info`/`ok`/`warn`/`err`/`die`
- `DRY_RUN`/`ASSUME_YES` defaults, `run()`
- `have()`/`is_tty()`, `load_mise()`
- `ask()`/`confirm()`
- `inject_block()`/`remove_block()` — including the unbalanced-marker guard and the one-time `.bak` backup

**Stays OS-side** — each `lib.sh` now sources the shared file (at the top) and keeps only its own bits:
- `scripts/lib.sh` (macOS): `is_macos`, `is_arm`, `brew_prefix`, `load_brew`
- `linux/scripts/lib.sh`: `is_linux`, `SUDO` + `can_sudo`, `detect_pm`/`PM`/`distro_id`, `pm_refresh`/`_PM_REFRESHED`, `pm_install`/`pm_try`/`pm_remove`, `load_local_bins`

Sourcing resolves each lib's own directory via `BASH_SOURCE` (`_KIT_LIB_DIR`), so it never depends on `$ROOT` or cwd. The `curl | bash` bootstrap clones the **full** repo, so `lib/common.sh` is always present for both trees. `# shellcheck source=lib/common.sh` directives let `shellcheck -x` resolve the chain.

Three trivial comment/whitespace diffs between the old copies were reconciled in `common.sh` (behavior-irrelevant): the aligned `DRY_RUN` comment, the more descriptive `confirm()` comment, and the "trim a single trailing blank line" comment in `inject_block()`.

## CI

Added `lib/common.sh` to the root `lint` job's `bash -n` list and `shellcheck` invocation. **`lint-linux` is intentionally unchanged**: its `shellcheck -x` already follows the `# shellcheck source=lib/common.sh` directive into the shared file (verified — no SC1091), and `lib/common.sh` is linted directly by the root `lint` job, so adding it to `lint-linux` too would only double-lint.

## Verification (pure refactor — behavior byte-for-byte identical)

- **`declare -f` identity**: every function (shared + OS-specific) and every top-level var (colors, `DRY_RUN`, `ASSUME_YES`, `PM`, `SUDO`, `_PM_REFRESHED`) dumps **identically** between `origin/main`'s `lib.sh` and the new `lib.sh`, for **both** trees.
- **Lint**: `bash -n` and `shellcheck -x -S warning -e SC2154` (exactly as CI runs them) clean on both trees plus `lib/common.sh`.
- **Dry-runs**: `./install.sh --dry-run` and `./uninstall.sh --dry-run --yes` produce output **identical** to `origin/main` (modulo the repo's own absolute path), exit 0.
- **Docker**: `ubuntu:24.04` running `bash linux/install.sh --dry-run --yes` (git installed, repo copied in) exits 0.
- **cwd independence**: both libs source correctly from an unrelated cwd.

> CI must pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)