### PR TITLE
fix(ci): remove stale uninstall checks from ZDOTDIR regression

### DIFF
--- a/tests/install-entrypoints.sh
+++ b/tests/install-entrypoints.sh
@@ -70,7 +70,7 @@ BOOTSTRAP_CHECKOUT="$TMP/bootstrap-checkout"
 git clone --quiet --no-hardlinks "$ROOT" "$BOOTSTRAP_CHECKOUT"
 if STARTER_KIT_REPO="$ROOT" \
   STARTER_KIT_DIR="$BOOTSTRAP_CHECKOUT" \
-  STARTER_KIT_BRANCH=main \
+  STARTER_KIT_BRANCH=HEAD \
   STARTER_KIT_COMMIT=0000000000000000000000000000000000000000 \
   bash -s -- --list < "$ROOT/install.sh" >/dev/null 2>&1
 then
@@ -78,13 +78,13 @@ then
 fi
 STARTER_KIT_REPO="$ROOT" \
 STARTER_KIT_DIR="$BOOTSTRAP_CHECKOUT" \
-STARTER_KIT_BRANCH=main \
+STARTER_KIT_BRANCH=HEAD \
 STARTER_KIT_COMMIT="$PINNED_COMMIT" \
   bash -s -- --list < "$ROOT/install.sh" >/dev/null
 printf 'local change\n' > "$BOOTSTRAP_CHECKOUT/untracked-change"
 if STARTER_KIT_REPO="$ROOT" \
   STARTER_KIT_DIR="$BOOTSTRAP_CHECKOUT" \
-  STARTER_KIT_BRANCH=main \
+  STARTER_KIT_BRANCH=HEAD \
   STARTER_KIT_COMMIT="$PINNED_COMMIT" \
   bash -s -- --list < "$ROOT/install.sh" >/dev/null 2>&1
 then

--- a/tests/zdotdir-existing-home.sh
+++ b/tests/zdotdir-existing-home.sh
@@ -222,15 +222,4 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     || fail "doctor: active ZDOTDIR/.zprofile was reported missing"
 fi
 
-env -u ZDOTDIR HOME="$zshenv_home" SHELL=/bin/zsh \
-  PATH="$zshenv_home/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
-  /bin/bash "$platform_root/uninstall.sh" --only shell --yes >/dev/null 2>&1
-if grep -qsF '# >>> lazy-starter-kit:' "$zshenv_zdot/.zshrc"; then
-  fail "uninstall: managed blocks remained in the active ZDOTDIR/.zshrc"
-fi
-if [[ "$(uname -s)" == "Darwin" ]] \
-  && grep -qsF '# >>> lazy-starter-kit:' "$zshenv_zdot/.zprofile"; then
-  fail "uninstall: managed blocks remained in the active ZDOTDIR/.zprofile"
-fi
-
 printf 'ok: install targets the Zsh startup directory used by existing users\n'


### PR DESCRIPTION
## Root cause

Commit `344c025` intentionally retired automatic uninstall on macOS, Linux, and Windows. However, `tests/zdotdir-existing-home.sh` still invoked the platform `uninstall.sh --only shell --yes` and then asserted that managed Zsh blocks had been removed.

Both retired uninstall entrypoints now fail closed by design (`uninstall.sh` exits 1 on macOS; `linux/uninstall.sh` exits 2 on Linux). Because the regression script uses `set -e`, that stale call aborts the test before its final success message. This matches scheduled runs 32698417107 and 32002542271, where `existing ZDOTDIR regression` failed on both macOS and Linux.

## Changes

- Remove only the obsolete uninstall invocation and uninstall assertions from `tests/zdotdir-existing-home.sh`.
- Make the bootstrap pinning fixture use the cloned repository's advertised `HEAD` instead of hard-coding a local `main` ref.

The second change fixes #12, which was exposed by this PR's first CI run: GitHub's synthetic PR checkout is detached and a local clone of it does not advertise `refs/heads/main`. The three fixture invocations therefore failed at `git fetch origin main` before testing bootstrap pinning. This is a test-fixture correction and does not change installer behavior.

All install, existing-ZDOTDIR, idempotency, active startup, doctor, quoting, damaged-marker, and bootstrap drift coverage remains intact.

## Tests

Local Linux:

- `bash -n tests/zdotdir-existing-home.sh`
- `tests/zdotdir-existing-home.sh`
- `tests/macos-existing-home.sh`
- `tests/safe-recursive-delete.sh`
- `tests/update-kit.sh`
- `tests/ai-shell-guard.sh`
- `git diff --check`
- Bootstrap mismatch, matching-pin, dirty-checkout, and dry-run cleanup cases from `tests/install-entrypoints.sh`, run from a neutral working directory (the remaining GUI build is macOS-only)

GitHub Actions run 33303026402 already confirmed the Issue #9 change:

- `shellcheck + syntax`: passed, including `existing ZDOTDIR regression`
- `macOS install + verify`: passed, including `existing ZDOTDIR regression`
- Linux and Windows install jobs: passed
- The sole failure was the separate detached-ref fixture tracked in #12 and fixed by the second commit

## Issues

This fixes the current weekly drift failure tracked by #9 without creating a duplicate issue. It also closes the distinct PR-checkout fixture failure documented in #12.

Closes #9
Closes #12