### PR TITLE
fix(bootstrap): reject unverified working-tree code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         run: tests/macos-existing-home.sh
       - name: existing ZDOTDIR regression
         run: tests/zdotdir-existing-home.sh
+      - name: piped bootstrap trust-boundary regression
+        run: tests/bootstrap-working-tree.sh
       - name: recursive deletion boundary regression
         run: tests/safe-recursive-delete.sh
       - name: detached update failure regression

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,6 @@ jobs:
         run: tests/macos-existing-home.sh
       - name: existing ZDOTDIR regression
         run: tests/zdotdir-existing-home.sh
-      - name: piped bootstrap trust-boundary regression
-        run: tests/bootstrap-working-tree.sh
       - name: recursive deletion boundary regression
         run: tests/safe-recursive-delete.sh
       - name: detached update failure regression
@@ -58,6 +56,8 @@ jobs:
           done
       - name: shellcheck
         run: shellcheck -x -S warning -e SC2154 linux/install.sh linux/scripts/*.sh
+      - name: piped bootstrap trust-boundary regression
+        run: tests/bootstrap-working-tree.sh
 
   linux-e2e:
     name: linux install + verify (ubuntu)

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,7 @@
 #
 set -euo pipefail
 
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-}"
 REPO_URL="${STARTER_KIT_REPO:-https://github.com/Heoooooon/lazy-starter-kit.git}"
 CLONE_DIR="${STARTER_KIT_DIR:-$HOME/.lazy-starter-kit}"
 # STARTER_KIT_BRANCH pins an explicit ref (a tag like v0.9.0, or "main" to ride
@@ -52,7 +53,7 @@ kit_latest_ref() {
 # Resolve the repo root, or bootstrap by cloning (supports curl | bash).
 # ---------------------------------------------------------------------------
 resolve_root() {
-  local src="${BASH_SOURCE[0]:-}"
+  local src="$SCRIPT_SOURCE"
   if [[ -n "$src" ]]; then
     local dir; dir="$(cd "$(dirname "$src")" 2>/dev/null && pwd || true)"
     if [[ -n "$dir" && -f "$dir/scripts/lib.sh" ]]; then
@@ -116,8 +117,8 @@ if [[ -n "$EPHEMERAL_ROOT" && "$ROOT" == "$EPHEMERAL_ROOT" ]]; then
 fi
 # Resolve this script's own absolute path (empty when piped from curl).
 SELF=""
-if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
-  SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || true)/$(basename "${BASH_SOURCE[0]}")"
+if [[ -n "$SCRIPT_SOURCE" ]]; then
+  SELF="$(cd "$(dirname "$SCRIPT_SOURCE")" 2>/dev/null && pwd || true)/$(basename "$SCRIPT_SOURCE")"
 fi
 # If we bootstrapped (cloned), hand off to the cloned copy with the original args.
 if [[ "$SELF" != "$ROOT/install.sh" && -f "$ROOT/install.sh" ]]; then

--- a/linux/install.sh
+++ b/linux/install.sh
@@ -28,6 +28,7 @@
 #
 set -euo pipefail
 
+SCRIPT_SOURCE="${BASH_SOURCE[0]:-}"
 REPO_URL="${STARTER_KIT_REPO:-https://github.com/Heoooooon/lazy-starter-kit.git}"
 CLONE_DIR="${STARTER_KIT_DIR:-$HOME/.lazy-starter-kit}"
 # STARTER_KIT_BRANCH pins an explicit ref (a tag like v0.9.0, or "main" to ride
@@ -49,7 +50,7 @@ kit_latest_ref() {
 # Resolve the repo root (the linux/ dir), or bootstrap by cloning (curl | bash).
 # ---------------------------------------------------------------------------
 resolve_root() {
-  local src="${BASH_SOURCE[0]:-}"
+  local src="$SCRIPT_SOURCE"
   if [[ -n "$src" ]]; then
     local dir; dir="$(cd "$(dirname "$src")" 2>/dev/null && pwd || true)"
     if [[ -n "$dir" && -f "$dir/scripts/lib.sh" ]]; then
@@ -65,6 +66,10 @@ resolve_root() {
   [[ -n "$REPO_BRANCH" ]] || REPO_BRANCH="$(kit_latest_ref)"
   echo "==> Using ${REPO_BRANCH}" >&2
   if [[ -d "$CLONE_DIR/.git" ]]; then
+    if [[ -n "$(git -C "$CLONE_DIR" status --porcelain --untracked-files=normal)" ]]; then
+      echo "Existing checkout has local changes; refusing to run: $CLONE_DIR" >&2
+      exit 1
+    fi
     # Fetch the exact ref, then detach onto it — works for both tags and
     # branches, unlike `pull --ff-only`. A failure here is reported instead of
     # silently installing from a stale checkout.
@@ -84,8 +89,8 @@ resolve_root() {
 ROOT="$(resolve_root)"
 # Resolve this script's own absolute path (empty when piped from curl).
 SELF=""
-if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
-  SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || true)/$(basename "${BASH_SOURCE[0]}")"
+if [[ -n "$SCRIPT_SOURCE" ]]; then
+  SELF="$(cd "$(dirname "$SCRIPT_SOURCE")" 2>/dev/null && pwd || true)/$(basename "$SCRIPT_SOURCE")"
 fi
 # If we bootstrapped (cloned), hand off to the cloned copy with the original args.
 if [[ "$SELF" != "$ROOT/install.sh" && -f "$ROOT/install.sh" ]]; then

--- a/tests/bootstrap-working-tree.sh
+++ b/tests/bootstrap-working-tree.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=lib/common.sh
+source "$ROOT/lib/common.sh"
+TMP_ROOT="$ROOT/.tmp-tests"
+mkdir -p "$TMP_ROOT"
+TMP="$(mktemp -d "$TMP_ROOT/bootstrap-working-tree.XXXXXX")"
+cleanup() {
+  safe_rm_rf_under "$TMP_ROOT" "$TMP"
+  rmdir "$TMP_ROOT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL %s\n' "$*" >&2
+  exit 1
+}
+
+# Build a local remote whose entrypoints only record that the verified checkout
+# ran. The real bootstrap scripts can then be exercised without network or OS
+# package mutations.
+FIXTURE_REPO="$TMP/fixture-repo"
+mkdir -p "$FIXTURE_REPO/linux"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "macos\n" > "$STARTER_KIT_PAYLOAD_MARKER"' \
+  > "$FIXTURE_REPO/install.sh"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "linux\n" > "$STARTER_KIT_PAYLOAD_MARKER"' \
+  > "$FIXTURE_REPO/linux/install.sh"
+git -C "$FIXTURE_REPO" init --quiet
+git -C "$FIXTURE_REPO" add install.sh linux/install.sh
+git -C "$FIXTURE_REPO" \
+  -c user.name='Bootstrap Test' \
+  -c user.email='bootstrap-test@example.invalid' \
+  commit --quiet -m fixture
+FIXTURE_REF="$(git -C "$FIXTURE_REPO" symbolic-ref --short HEAD)"
+
+# Bash gives a stdin script the pseudo-source name "main" inside a function.
+# A decoy cwd containing both that filename and scripts/lib.sh must never be
+# mistaken for the installer source tree.
+DECOY="$TMP/decoy-cwd"
+mkdir -p "$DECOY/scripts"
+printf 'pseudo source sentinel\n' > "$DECOY/main"
+printf '%s\n' \
+  'printf "decoy\n" > "$STARTER_KIT_DECOY_MARKER"' \
+  'exit 97' \
+  > "$DECOY/scripts/lib.sh"
+
+run_piped_bootstrap() {
+  local platform="$1" installer="$2" expected="$3"
+  local clone_dir="$TMP/$platform-clone"
+  local payload_marker="$TMP/$platform-payload"
+  local decoy_marker="$TMP/$platform-decoy"
+
+  if ! (
+    cd "$DECOY"
+    STARTER_KIT_REPO="$FIXTURE_REPO" \
+    STARTER_KIT_DIR="$clone_dir" \
+    STARTER_KIT_BRANCH="$FIXTURE_REF" \
+    STARTER_KIT_PAYLOAD_MARKER="$payload_marker" \
+    STARTER_KIT_DECOY_MARKER="$decoy_marker" \
+      bash -s -- --list < "$installer"
+  ) >/dev/null 2>&1; then
+    fail "$platform piped bootstrap did not execute its verified checkout"
+  fi
+  [[ ! -e "$decoy_marker" ]] \
+    || fail "$platform piped bootstrap sourced code from its current directory"
+  [[ -f "$payload_marker" && "$(<"$payload_marker")" == "$expected" ]] \
+    || fail "$platform piped bootstrap did not hand off to the cloned payload"
+}
+
+run_piped_bootstrap macos "$ROOT/install.sh" macos
+run_piped_bootstrap linux "$ROOT/linux/install.sh" linux
+printf 'ok   piped bootstraps ignore decoy working-tree code\n'
+
+# An existing Linux checkout whose tracked payload was modified must be rejected
+# before fetch/checkout can retain and execute that local content.
+DIRTY_CHECKOUT="$TMP/dirty-checkout"
+git clone --quiet --branch "$FIXTURE_REF" "$FIXTURE_REPO" "$DIRTY_CHECKOUT"
+DIRTY_MARKER="$TMP/dirty-payload"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "dirty\n" > "$STARTER_KIT_PAYLOAD_MARKER"' \
+  > "$DIRTY_CHECKOUT/linux/install.sh"
+mkdir -p "$TMP/neutral-cwd"
+status=0
+(
+  cd "$TMP/neutral-cwd"
+  STARTER_KIT_REPO="$FIXTURE_REPO" \
+  STARTER_KIT_DIR="$DIRTY_CHECKOUT" \
+  STARTER_KIT_BRANCH="$FIXTURE_REF" \
+  STARTER_KIT_PAYLOAD_MARKER="$DIRTY_MARKER" \
+    bash -s -- --list < "$ROOT/linux/install.sh"
+) >/dev/null 2>&1 || status=$?
+[[ "$status" -ne 0 ]] \
+  || fail "Linux bootstrap accepted a dirty existing checkout"
+[[ ! -e "$DIRTY_MARKER" ]] \
+  || fail "Linux bootstrap executed modified tracked content"
+printf 'ok   Linux bootstrap rejects a dirty existing checkout\n'
+
+printf 'PASS bootstrap working-tree trust boundary\n'


### PR DESCRIPTION
## Root cause

The Bash installers read `${BASH_SOURCE[0]}` for the first time inside `resolve_root()`. With `bash -s`, top-level `BASH_SOURCE` is empty but Bash 5 reports the pseudo-source `main` inside the function. From a working directory containing `scripts/lib.sh`, both piped installers can therefore trust and source the current directory instead of cloning/verifying the selected ref.

Separately, the Linux bootstrap does not reject local changes in an existing checkout. A checkout of the already-current commit can succeed while retaining modified tracked content, which is then executed.

## Changes

- Capture the real script source once at top level and reuse it for root and self resolution in macOS and Linux installers.
- Reject dirty existing Linux bootstrap checkouts before fetch/checkout.
- Add a network-free Linux regression that:
  - runs both piped installers from a decoy cwd containing `main` and `scripts/lib.sh`;
  - confirms handoff to a local verified fixture checkout;
  - confirms Linux refuses a modified tracked payload.
- Run the regression in the Ubuntu lint job.

## Tests

Passed locally on Linux:

- `bash -n install.sh linux/install.sh tests/bootstrap-working-tree.sh`
- `tests/bootstrap-working-tree.sh`
- `./install.sh --list`
- `./linux/install.sh --list`
- `tests/zdotdir-existing-home.sh`
- `tests/macos-existing-home.sh`
- `tests/safe-recursive-delete.sh`
- `tests/update-kit.sh`
- `tests/ai-shell-guard.sh`
- `git diff --check`

ShellCheck is not installed in the local review environment; the PR workflow runs it.

## Existing work

This is not a duplicate of PR #8. That PR makes Linux fetch/checkout failures fail closed; this change rejects a checkout that is already dirty even when checkout itself can return success. The adjacent edits may need reconciliation depending on merge order.

Closes #13