### PR TITLE
fix(windows): fail closed on damaged managed markers

### DIFF
--- a/tests/windows-safe-remove.ps1
+++ b/tests/windows-safe-remove.ps1
@@ -44,6 +44,49 @@ try {
   $script:DryRun = $false
   if (-not (Test-Path -LiteralPath $dry)) { Fail 'dry-run deleted a target' }
 
+  $tag = 'lazy-starter-kit:test'
+  $begin = "# >>> $tag >>>"
+  $end = "# <<< $tag <<<"
+  $encoding = New-Object System.Text.UTF8Encoding($true)
+  $damagedCases = @(
+    @{ Name = 'out-of-order'; Lines = @('user-before', $end, 'user-middle', $begin, 'user-after') },
+    @{ Name = 'duplicate-begin'; Lines = @('user-before', $begin, 'managed', $end, $begin, 'user-after') }
+  )
+  foreach ($damagedCase in $damagedCases) {
+    $profile = Join-Path $allowed ("profile-{0}.ps1" -f $damagedCase.Name)
+    [IO.File]::WriteAllLines($profile, [string[]]$damagedCase.Lines, $encoding)
+    $before = [Convert]::ToBase64String([IO.File]::ReadAllBytes($profile))
+    Update-ManagedBlock -Path $profile -Tag $tag -Content 'replacement'
+    if ([Convert]::ToBase64String([IO.File]::ReadAllBytes($profile)) -ne $before) {
+      Fail "Update-ManagedBlock changed a $($damagedCase.Name) profile"
+    }
+    Remove-ManagedBlock -Path $profile -Tag $tag
+    if ([Convert]::ToBase64String([IO.File]::ReadAllBytes($profile)) -ne $before) {
+      Fail "Remove-ManagedBlock changed a $($damagedCase.Name) profile"
+    }
+    if (Test-Path -LiteralPath "$profile.lazy-starter-kit.bak") {
+      Fail "damaged $($damagedCase.Name) markers created a rewrite backup"
+    }
+  }
+
+  $validProfile = Join-Path $allowed 'profile-valid.ps1'
+  [IO.File]::WriteAllLines(
+    $validProfile,
+    [string[]]@('user-before', $begin, 'old-managed', $end, 'user-after'),
+    $encoding
+  )
+  Update-ManagedBlock -Path $validProfile -Tag $tag -Content 'new-managed'
+  $updated = [IO.File]::ReadAllLines($validProfile, $encoding)
+  if (($updated -notcontains 'new-managed') -or ($updated -contains 'old-managed')) {
+    Fail 'valid managed block was not updated'
+  }
+  Remove-ManagedBlock -Path $validProfile -Tag $tag
+  $removed = [IO.File]::ReadAllLines($validProfile, $encoding)
+  if (($removed.Count -ne 2) -or $removed[0] -ne 'user-before' -or $removed[1] -ne 'user-after') {
+    Fail 'valid managed block removal did not preserve surrounding content'
+  }
+  Write-Output 'ok: Windows managed blocks fail closed on damaged markers'
+
   $junction = Join-Path $allowed 'junction'
   New-Item -ItemType Junction -Path $junction -Target $outside | Out-Null
   Expect-Throw { Remove-KitTree -AllowedRoot $allowed -Path $junction } 'junction target'

--- a/windows/scripts/lib.ps1
+++ b/windows/scripts/lib.ps1
@@ -357,6 +357,33 @@ function Get-ProfileEncoding {
 # Update-ManagedBlock -Path <file> -Tag <tag> -Content <string>
 # Re-running replaces the block; never duplicates.
 # ---------------------------------------------------------------------------
+function Get-ManagedBlockState {
+  param(
+    [AllowEmptyCollection()][string[]]$Lines,
+    [Parameter(Mandatory)][string]$Begin,
+    [Parameter(Mandatory)][string]$End
+  )
+  $beginCount = 0
+  $endCount = 0
+  $beginIndex = -1
+  $endIndex = -1
+  for ($i = 0; $i -lt $Lines.Count; $i++) {
+    if ($Lines[$i] -eq $Begin) {
+      if ($beginIndex -lt 0) { $beginIndex = $i }
+      $beginCount++
+    }
+    if ($Lines[$i] -eq $End) {
+      if ($endIndex -lt 0) { $endIndex = $i }
+      $endCount++
+    }
+  }
+  if ($beginCount -eq 0 -and $endCount -eq 0) { return 'absent' }
+  if ($beginCount -eq 1 -and $endCount -eq 1 -and $beginIndex -lt $endIndex) {
+    return 'valid'
+  }
+  return 'damaged'
+}
+
 function Update-ManagedBlock {
   param(
     [Parameter(Mandatory)][string]$Path,
@@ -371,21 +398,20 @@ function Update-ManagedBlock {
   # don't corrupt a profile with Korean comments on WinPS 5.1.
   $enc = Get-ProfileEncoding $Path
 
-  # Refuse to touch a file whose markers are unbalanced (crashed run / hand-edit):
-  # rewriting would drop everything between the lone marker and EOF -- the user's
-  # own config. Mirrors inject_block in the bash kits.
+  # Refuse to touch a file whose markers are unmatched, duplicated, or out of order:
+  # rewriting could drop user content through EOF. Mirrors inject_block in Bash.
+  $blockState = 'absent'
   if (Test-Path $Path) {
     $existing = [System.IO.File]::ReadAllLines($Path, $enc)
-    $hasBegin = $existing -contains $begin
-    $hasEnd   = $existing -contains $end
-    if ($hasBegin -ne $hasEnd) {
-      Write-Warn "$short has an unmatched lazy-starter-kit '$Tag' marker; refusing to modify it. Fix or delete the stray marker line by hand."
+    $blockState = Get-ManagedBlockState -Lines $existing -Begin $begin -End $end
+    if ($blockState -eq 'damaged') {
+      Write-Warn "$short has malformed lazy-starter-kit '$Tag' markers; refusing to modify it. Keep exactly one begin marker before exactly one end marker, or delete the stray marker lines by hand."
       return
     }
   }
 
   if ($script:DryRun) {
-    if ((Test-Path $Path) -and (Select-String -Path $Path -SimpleMatch $begin -Quiet)) {
+    if ($blockState -eq 'valid') {
       Write-Info "[dry-run] would update '$Tag' block in $short"
     } else {
       Write-Info "[dry-run] would add '$Tag' block to $short"
@@ -431,16 +457,14 @@ function Remove-ManagedBlock {
   # Preserve the file's existing encoding on read and write-back (see Get-ProfileEncoding).
   $enc = Get-ProfileEncoding $Path
 
-  # Refuse on unbalanced markers (see Update-ManagedBlock): a lone begin marker
-  # would make the skip loop drop the user's own config below it.
+  # Refuse on every malformed marker layout (see Update-ManagedBlock).
   $existing = [System.IO.File]::ReadAllLines($Path, $enc)
-  $hasBegin = $existing -contains $begin
-  $hasEnd   = $existing -contains $end
-  if ($hasBegin -ne $hasEnd) {
-    Write-Warn "$short has an unmatched lazy-starter-kit '$Tag' marker; refusing to modify it. Fix or delete the stray marker line by hand."
+  $blockState = Get-ManagedBlockState -Lines $existing -Begin $begin -End $end
+  if ($blockState -eq 'damaged') {
+    Write-Warn "$short has malformed lazy-starter-kit '$Tag' markers; refusing to modify it. Keep exactly one begin marker before exactly one end marker, or delete the stray marker lines by hand."
     return
   }
-  if (-not $hasBegin) { Write-Info "no '$Tag' block in $short"; return }
+  if ($blockState -eq 'absent') { Write-Info "no '$Tag' block in $short"; return }
 
   if ($script:DryRun) { Write-Info "[dry-run] would remove '$Tag' block from $short"; return }
 


### PR DESCRIPTION
## Root cause

The Windows managed-block helpers only compared whether a begin marker and an end marker existed. That rejects a lone marker but accepts duplicate markers and an end marker appearing before the begin marker.

The rewrite loop then starts skipping at a late/duplicate begin marker and can discard unrelated profile content through EOF. This contradicts the documented fail-closed marker contract and the stricter Bash implementation.

## Changes

- Add one marker-state validator shared by update and removal.
- Accept only:
  - no markers (`absent`), or
  - exactly one begin followed by exactly one end (`valid`).
- Refuse every other layout as `damaged` before backup or write.
- Add regressions for out-of-order and duplicate-begin layouts, asserting both update and removal leave the file byte-for-byte unchanged and create no backup.
- Retain a valid update/remove round-trip assertion for surrounding user content.

## Tests

- `git diff --check` passed locally.
- PowerShell is not installed in the local review environment, so the executable regression could not be run locally.
- The existing workflow runs `tests/windows-safe-remove.ps1` on both Windows PowerShell 5.1 and PowerShell 7, plus parser and PSScriptAnalyzer jobs; those PR checks are the platform verification for this change.

Closes #15