### PR TITLE
fix(windows): enforce Doctor config exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
         run: |
           $fail = 0
           @(Get-ChildItem -Path windows,gui/windows -Recurse -Include *.ps1) + @(
-            Get-Item tests/windows-safe-remove.ps1,tests/windows-install-entrypoints.ps1
+            Get-Item tests/windows-safe-remove.ps1,tests/windows-install-entrypoints.ps1,tests/windows-doctor.ps1
           ) | ForEach-Object {
             $tokens = $null; $errors = $null
             $null = [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$errors)
@@ -335,6 +335,10 @@ jobs:
             Write-Host "ok   profile block"
           } else { Write-Host "MISS profile block"; $fail = 1 }
           exit $fail
+
+      - name: doctor config exit code regression
+        shell: pwsh
+        run: .\tests\windows-doctor.ps1
 
   cron-failure-alert:
     name: alert on scheduled-run failure

--- a/tests/windows-doctor.ps1
+++ b/tests/windows-doctor.ps1
@@ -1,0 +1,66 @@
+#requires -Version 5.1
+$ErrorActionPreference = 'Stop'
+
+$Root = Split-Path -Parent $PSScriptRoot
+$Installer = Join-Path $Root 'windows\install.ps1'
+$HostExe = (Get-Process -Id $PID).Path
+
+# Refresh the paths persisted by installers; GitHub Actions step processes do
+# not inherit the previous step's in-process PATH refresh.
+$pathParts = @(
+  $env:Path,
+  [Environment]::GetEnvironmentVariable('Path', 'Machine'),
+  [Environment]::GetEnvironmentVariable('Path', 'User'),
+  (Join-Path $env:USERPROFILE '.cargo\bin'),
+  (Join-Path $env:USERPROFILE '.bun\bin'),
+  (Join-Path $env:USERPROFILE '.local\bin'),
+  (Join-Path $env:LOCALAPPDATA 'mise\shims'),
+  (Join-Path $env:APPDATA 'npm')
+) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+$env:Path = $pathParts -join ';'
+
+function Invoke-DoctorProcess {
+  $process = Start-Process `
+    -FilePath $HostExe `
+    -ArgumentList @('-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $Installer, '-Doctor') `
+    -NoNewWindow `
+    -Wait `
+    -PassThru
+  return $process.ExitCode
+}
+
+function Assert-DoctorFailsWithoutFile {
+  param([Parameter(Mandatory)][string]$Path, [Parameter(Mandatory)][string]$Label)
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    throw "Doctor regression fixture is missing $Label before the test: $Path"
+  }
+  $hidden = "$Path.doctor-test-$PID"
+  if (Test-Path -LiteralPath $hidden) {
+    throw "Doctor regression backup path already exists: $hidden"
+  }
+  Move-Item -LiteralPath $Path -Destination $hidden
+  try {
+    $code = Invoke-DoctorProcess
+    if ($code -ne 1) { throw "Doctor returned $code with $Label missing; expected 1" }
+  } finally {
+    Move-Item -LiteralPath $hidden -Destination $Path
+  }
+}
+
+if ((Invoke-DoctorProcess) -ne 0) {
+  throw 'Doctor did not return 0 for the healthy installed environment'
+}
+
+$script:RunFromFile = $false
+. (Join-Path $Root 'windows\scripts\lib.ps1')
+$profilePath = @(Get-AllHostsProfilePaths)[0]
+$starshipPath = Join-Path $env:USERPROFILE '.config\starship.toml'
+
+Assert-DoctorFailsWithoutFile -Path $profilePath -Label 'managed PowerShell profile'
+Assert-DoctorFailsWithoutFile -Path $starshipPath -Label 'starship.toml'
+
+if ((Invoke-DoctorProcess) -ne 0) {
+  throw 'Doctor did not return to healthy status after restoring config fixtures'
+}
+
+Write-Output 'PASS Windows Doctor config exit-code contract'

--- a/windows/install.ps1
+++ b/windows/install.ps1
@@ -401,6 +401,7 @@ function Invoke-Doctor {
       Write-Ok "profile block present ($short)"
     } else {
       Write-Warn "profile block missing ($short) -- fix: .\install.ps1 -Only shell"
+      $missing++
     }
   }
   # starship.toml (04-shell.ps1 installs it at ~\.config\starship.toml)
@@ -409,6 +410,7 @@ function Invoke-Doctor {
     Write-Ok "starship.toml present (~\.config\starship.toml)"
   } else {
     Write-Warn "starship.toml missing (~\.config\starship.toml) -- fix: .\install.ps1 -Only shell"
+    $missing++
   }
 
   Write-Step "Summary"


### PR DESCRIPTION
## Root cause

Windows Doctor increments its missing counter for tools and runtimes, but not for the two required CurrentUserAllHosts profile blocks or `~\.config\starship.toml`. It therefore warns about incomplete shell configuration and still returns 0, contrary to the installer help and `VERSIONING.md` exit-code contract.

## Changes

- Count each missing required profile block.
- Count a missing `starship.toml`.
- Add a post-install Windows regression that:
  - refreshes persisted tool paths;
  - confirms a healthy install returns 0;
  - temporarily hides one managed profile and then `starship.toml`, confirming each produces exit 1;
  - restores both files and confirms Doctor returns to 0.
- Include the new test in portable PowerShell parsing.

PATH-only findings remain warnings and do not fail Doctor.

## Tests

- `git diff --check` passed locally.
- PowerShell is not installed in the local review environment, so the executable Windows test could not be run locally.
- The PR workflow runs PowerShell parsing and the new regression after the real Windows install/verification job.

Closes #17