### PR TITLE
docs: align remaining surfaces with uninstall policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ first saves everyone time. Issues and PRs are welcome — in Korean or English.
 ## Repo layout
 
 ```
-.               macOS kit (install.sh, uninstall.sh, scripts/, Brewfile)
+.               macOS kit (install.sh, scripts/, Brewfile; legacy uninstall stub)
 lib/common.sh   helpers shared by the macOS and Linux kits (sourced by both)
 linux/          Linux kit (mirrors the macOS tree)
 windows/        Windows kit (PowerShell 5.1 + 7)
@@ -47,7 +47,7 @@ PRs that add non-core tools to the base will be asked to move them to
   `mapfile`, `${x,,}`, etc. (`bash -n` must pass under `/bin/bash`).
 - **Idempotent & non-destructive** — re-running must be safe; never clobber a
   user's existing config (fill empty values, use the managed-block markers).
-- **shellcheck clean** — `shellcheck -x -S warning -e SC2154 install.sh uninstall.sh lib/common.sh scripts/*.sh`.
+- **shellcheck clean** — `shellcheck -x -S warning -e SC2154 install.sh lib/common.sh scripts/*.sh tests/*.sh`.
 - **Shared helpers live in `lib/common.sh`** — the OS-agnostic bash helpers
   (colors, `run`, `ask`/`confirm`, `inject_block`, …) are shared by the macOS
   (`scripts/lib.sh`) and Linux (`linux/scripts/lib.sh`) kits, which source it and
@@ -60,9 +60,9 @@ PRs that add non-core tools to the base will be asked to move them to
   pipeline chains; `Set-StrictMode -Version Latest` must pass, and native
   commands that write stderr are wrapped (`Invoke-NativeSilently`) because
   scripts run with `$ErrorActionPreference = 'Stop'`.
-- **Preview first** — verify with `./install.sh --dry-run` (and `--dry-run` for
-  uninstall).
-- **CI must pass** — lint + macOS dry-run + a real install→uninstall run.
+- **Preview first** — verify installer changes with `./install.sh --dry-run`.
+- **CI must pass** — lint, dry-run, real install/verification, idempotency,
+  Doctor, upgrade, and safety regressions.
 - **Versioning** — user-visible changes bump [`VERSION`](./VERSION) and get a
   note in [`CHANGELOG.md`](./CHANGELOG.md). The flags, step ids, managed-block
   markers, and env vars are a **semver contract** — see
@@ -75,8 +75,9 @@ Run what CI runs:
 ```sh
 # bash kits — lint
 bash -n install.sh linux/install.sh lib/common.sh
-shellcheck -x -S warning -e SC2154 install.sh uninstall.sh lib/common.sh \
-  scripts/*.sh scripts/ai/lazy-safe-rm linux/install.sh linux/uninstall.sh linux/scripts/*.sh
+shellcheck -x -S warning -e SC2154 install.sh lib/common.sh \
+  scripts/*.sh scripts/ai/lazy-safe-rm tests/*.sh
+shellcheck -x -S warning -e SC2154 linux/install.sh linux/scripts/*.sh
 node --check scripts/ai/shell-command-guard.js
 node --check scripts/ai/install-shell-guard.js
 tests/macos-existing-home.sh
@@ -100,10 +101,10 @@ docker run --rm -v "$PWD":/src ubuntu:24.04 bash -c \
    cp -r /src /kit && cd /kit && bash linux/install.sh --yes --skip docker'
 ```
 
-CI then runs the full install → verify → idempotency → doctor → uninstall cycle
-on macOS, Windows, Ubuntu, Fedora, Arch, and openSUSE Tumbleweed, plus an
-upgrade-path test — the checks above are enough to make a PR worth opening;
-the matrix catches the rest.
+CI then runs full installation and verification on macOS, Windows, Ubuntu,
+Fedora, Arch, and openSUSE Tumbleweed, plus platform-specific idempotency,
+Doctor, upgrade-path, and safety regressions. Automatic uninstall is retired;
+the legacy entrypoints are non-destructive stubs and are not a CI teardown step.
 
 ## Releases (maintainers)
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -11,7 +11,7 @@ Breaking any of these requires a **major** version bump:
 | Surface | Examples |
 |---|---|
 | **CLI flags** | `--only`, `--skip`, `--dry-run`, `--yes`, `--profile`, `--doctor`, `--update`, `--list`, `--version`, `--with-gajae` (Windows: the `-PascalCase` equivalents) |
-| **Step / group ids** | install steps (`prereqs`, `brew`/`packages`, `runtimes`, `shell`, `docker`, `git`, `agents`, `wsl`) and uninstall groups — the values accepted by `--only`/`--skip` |
+| **Step ids** | install steps (`prereqs`, `brew`/`packages`, `runtimes`, `shell`, `docker`, `git`, `agents`, `wsl`) — the values accepted by `--only`/`--skip` |
 | **Profile names** | `full`, `minimal`, `work` |
 | **Managed-block markers** | `# >>> lazy-starter-kit:<tag> >>>` … `# <<< lazy-starter-kit:<tag> <<<` in `${ZDOTDIR-$HOME}/.zshrc`, `${ZDOTDIR-$HOME}/.zprofile`, PowerShell profiles — tools and users may key on these |
 | **Environment variables** | `STARTER_KIT_BRANCH` (pin an explicit ref; unset installs the newest release tag), `STARTER_KIT_COMMIT` (require that ref to resolve to one full 40-character commit SHA), `HERMES=1` (opt in to the Hermes agent, macOS/Linux), `ZDOTDIR` (non-empty absolute Zsh config directory), `ASSUME_YES`/CI non-interactive behavior |
@@ -39,7 +39,7 @@ From `v1.0.0` on, the table above is a hard promise.
 
 | Tier | Platforms | Promise |
 |---|---|---|
-| **Tier 1** | macOS 14+ (Apple Silicon) · Windows Server 2025 (≈ Windows 11) · Ubuntu 24.04 · Fedora (latest) · Arch (latest) · openSUSE Tumbleweed | Full install → verify → uninstall runs in CI **on every commit**, plus idempotency (second install) and upgrade-path (previous tag → main) tests |
+| **Tier 1** | macOS 14+ (Apple Silicon) · Windows Server 2025 (≈ Windows 11) · Ubuntu 24.04 · Fedora (latest) · Arch (latest) · openSUSE Tumbleweed | Full install and verification run in CI **on every commit**, plus platform-specific idempotency, Doctor, upgrade-path, and safety regressions |
 | **Tier 2** | Windows 10 1809+ / 11 desktop · Debian 12+ · RHEL 9 / Rocky / Alma · openSUSE Leap · WSL2 (Ubuntu) · Intel Macs | Expected to work (same code paths), not automatically tested; regressions fixed with priority when reported |
 | **Unsupported** | Alpine / musl distros · 32-bit systems | Upstream tools (node, ast-grep, bun) don't ship builds |
 

--- a/assets/readme/hero.svg
+++ b/assets/readme/hero.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 540" width="1200" height="540" role="img" aria-labelledby="lsk-hero-title lsk-hero-desc">
   <title id="lsk-hero-title">lazy-starter-kit — 명령어 한 줄로 새 컴퓨터를 개발 환경으로</title>
-  <desc id="lsk-hero-desc">왼쪽에는 프로젝트 이름과 한 줄 설명, 오른쪽에는 커밋마다 설치·검증·제거를 e2e로 돌리는 CI 대상 6개 플랫폼(macOS, Windows, Ubuntu, Fedora, Arch, openSUSE) 목록, 아래에는 잘리지 않은 전체 설치 명령어가 있습니다.</desc>
+  <desc id="lsk-hero-desc">왼쪽에는 프로젝트 이름과 한 줄 설명, 오른쪽에는 커밋마다 설치·검증을 e2e로 돌리는 CI 대상 6개 플랫폼(macOS, Windows, Ubuntu, Fedora, Arch, openSUSE) 목록, 아래에는 잘리지 않은 전체 설치 명령어가 있습니다.</desc>
 
   <rect width="1200" height="540" rx="18" fill="#0d1117"/>
   <rect x="0.5" y="0.5" width="1199" height="539" rx="17.5" fill="none" stroke="#21262d"/>
@@ -25,7 +25,7 @@
   <!-- 우: 진짜 차별점 = CI 실측 -->
   <g>
     <rect x="660" y="48" width="476" height="330" rx="14" fill="#161b22" stroke="#21262d"/>
-    <text x="692" y="88" font-size="17" font-weight="700" fill="#8b949e" letter-spacing="1.4" font-family="ui-sans-serif, -apple-system, 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', Helvetica, Arial, sans-serif">커밋마다 CI · 설치 → 검증 → 제거</text>
+    <text x="692" y="88" font-size="17" font-weight="700" fill="#8b949e" letter-spacing="1.4" font-family="ui-sans-serif, -apple-system, 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', Helvetica, Arial, sans-serif">커밋마다 CI · 설치 → 검증 → 안전 회귀</text>
     <path d="M692 104 L1104 104" stroke="#21262d" stroke-width="2"/>
 
     <g font-family="ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace" font-size="21">

--- a/docs/index.html
+++ b/docs/index.html
@@ -965,7 +965,7 @@
       </li>
       <li class="proof">
         <strong>6 environments in CI</strong>
-        <span>설치부터 제거까지 자동으로 검증합니다.</span>
+        <span>설치·검증·반복 실행과 안전 회귀를 자동으로 확인합니다.</span>
       </li>
     </ul>
 
@@ -1027,8 +1027,8 @@
             <span>같은 설치를 다시 실행해도 설정 블록이 중복되거나 손상되지 않습니다.</span>
           </div>
           <div class="safety-item">
-            <strong>제거와 수동 복구</strong>
-            <span>키트가 관리하는 설정을 정리하고 백업은 수동 복구용으로 남깁니다. Homebrew·Git 정보·폰트 같은 외부 상태는 유지합니다.</span>
+            <strong>수동 제거와 복구</strong>
+            <span>자동 제거는 지원하지 않습니다. 도구별 공식 제거 안내와 설정 백업을 이용해 사용자가 소유한 상태를 직접 확인합니다.</span>
           </div>
         </div>
       </div>

--- a/linux/README.md
+++ b/linux/README.md
@@ -35,7 +35,8 @@ cd lazy-starter-kit/linux
 Fedora/RHEL (`dnf`/`yum`), Arch (`pacman`), openSUSE (`zypper`) — all **glibc**.
 Alpine/musl (`apk`) is **not supported** (upstream node, ast-grep and bun ship
 no musl builds). Ubuntu, Fedora, openSUSE and Arch are all verified
-end-to-end (install → verify → uninstall) in CI on every change.
+with a full install and verification in CI on every change; Ubuntu also covers
+idempotency and the Doctor exit-code contract.
 
 ## What you get
 
@@ -75,7 +76,7 @@ duplicated) on re-runs. Existing files you own are preserved.
 
 The agents step also installs a Codex/Claude Code `PreToolUse` guard that blocks
 recursive `rm` and provides `lazy-safe-rm` for strict descendants of the current
-Git workspace. Recursive installer/uninstaller cleanup independently validates
+Git workspace. Recursive internal cleanup independently validates
 physical containment and refuses root, HOME, boundary, outside, and symlink targets.
 
 ## Design notes
@@ -96,23 +97,16 @@ physical containment and refuses root, HOME, boundary, outside, and symlink targ
   installs docker-ce + compose + buildx and adds you to the `docker` group
   (effective after re-login).
 
-## Uninstall
+## Automatic uninstall is not supported
 
-```sh
-./uninstall.sh --dry-run     # preview the teardown
-./uninstall.sh               # run it (destructive groups are confirm-gated)
-./uninstall.sh --yes         # non-interactive, accept every removal
-./uninstall.sh --only agents # remove just one group
-```
+The legacy `uninstall.sh` entrypoint is a non-destructive stub and performs no
+removal. The kit cannot reliably distinguish tools it installed from tools that
+already belonged to the user, so removing packages or paths automatically could
+delete an existing development environment, configuration, auth state, or data.
 
-Groups (reverse order): `agents shell docker runtimes packages`.
-
-Safe by design:
-- **Never auto-removed**: your **git identity**, and the compiler/build tools.
-- **gajae-code (`gjc`) is kept** unless you pass `--with-gajae`.
-- Removing codex backs up `~/.codex/auth.json` first; `--keep-codex-home` leaves
-  `~/.codex` intact.
-- Only the kit's own managed blocks are stripped from `${ZDOTDIR-$HOME}/.zshrc`.
+To remove a particular tool, follow that tool's official uninstall instructions.
+Inspect `${ZDOTDIR-$HOME}/.zshrc` and manually remove blocks marked
+`lazy-starter-kit` if you no longer want the managed shell configuration.
 
 ## Troubleshooting
 

--- a/linux/scripts/07-agents.sh
+++ b/linux/scripts/07-agents.sh
@@ -119,6 +119,6 @@ step_agents() {
   # Gemini CLI's closed-source successor (`agy`) has a small free tier and its
   # own account flow, so it is a manual one-liner documented in the README
   # next to Grok Build:  curl -fsSL https://antigravity.google/cli/install.sh | bash
-  # uninstall.sh still removes ~/.local/bin/agy when present, so a manually
-  # installed copy is torn down with the rest of the kit.
+  # Automatic uninstall is retired; a manually installed copy remains
+  # user-owned and must be removed using its official instructions.
 }

--- a/scripts/07-agents.sh
+++ b/scripts/07-agents.sh
@@ -123,6 +123,6 @@ step_agents() {
   # Gemini CLI's closed-source successor (`agy`) has a small free tier and its
   # own account flow, so it is a manual one-liner documented in the README
   # next to Grok Build:  curl -fsSL https://antigravity.google/cli/install.sh | bash
-  # uninstall.sh still removes ~/.local/bin/agy when present, so a manually
-  # installed copy is torn down with the rest of the kit.
+  # Automatic uninstall is retired; a manually installed copy remains
+  # user-owned and must be removed using its official instructions.
 }

--- a/windows/README.md
+++ b/windows/README.md
@@ -162,33 +162,18 @@ next run picks up from wherever it left off (initialize → run the Linux kit).
 > unattended, and CI can't do nested virtualization). Use `-Only wsl` to run it
 > explicitly, or `-Skip wsl` to leave it out.
 
-## Uninstall
+## Automatic uninstall is not supported
 
-```powershell
-.\uninstall.ps1 -DryRun     # preview the teardown
-.\uninstall.ps1             # run it (destructive groups are confirm-gated)
-.\uninstall.ps1 -Yes        # non-interactive, accept every removal
-.\uninstall.ps1 -Only agents
-```
+The legacy `uninstall.ps1` entrypoint is a non-destructive stub and performs no
+removal. The kit cannot reliably distinguish tools it installed from tools that
+already belonged to the user, so automatic package, profile, or WSL teardown
+could remove pre-existing tools, configuration, auth state, or data.
 
-Groups (reverse order): `wsl agents shell docker runtimes packages`.
-
-Safe by design:
-- **WSL distro is never auto-removed**: the `wsl` group offers
-  `wsl --unregister Ubuntu` behind a **default-No** prompt with an explicit
-  **data-loss** warning (unregister permanently deletes the whole distro
-  filesystem). It's **never** run under `-Yes`. **WSL itself stays installed** —
-  only the Ubuntu distro is offered for removal.
-- **Never auto-removed**: your **git identity**, `git` itself, and the Nerd Font.
-- **gajae-code (`gjc`) is kept** unless you pass `-WithGajae` (refused while running).
-- Removing codex backs up `~/.codex/auth.json` first; `-KeepCodexHome` leaves it intact.
-- Recursive cleanup is centralized in `Remove-KitTree`: it requires a strict
-  descendant of an explicit root and rejects drive roots, `USERPROFILE`, outside
-  paths, dot segments, and junction/reparse-point traversal before deletion.
-- The agents step installs the same Codex/Claude Code recursive-`rm` hook used by
-  the macOS/Linux kits. `lazy-safe-rm.cmd` delegates guarded workspace cleanup to
-  Git Bash, which is installed with Git for Windows.
-- Only the kit's own managed block is stripped from your PowerShell profile.
+To remove a particular tool, follow that tool's official uninstall instructions.
+Inspect both CurrentUserAllHosts PowerShell profiles and manually remove blocks
+marked `lazy-starter-kit` if you no longer want the managed shell configuration.
+Never run `wsl --unregister` unless you intend to permanently delete that distro's
+entire filesystem.
 
 ## Troubleshooting
 

--- a/windows/scripts/07-agents.ps1
+++ b/windows/scripts/07-agents.ps1
@@ -111,6 +111,6 @@ function Step-Agents {
   # Gemini CLI's closed-source successor (`agy`) has a small free tier and its
   # own account flow, so it is a manual one-liner documented in the README
   # next to Grok Build:  irm https://antigravity.google/cli/install.ps1 | iex
-  # uninstall.ps1 still removes %LOCALAPPDATA%\agy when present, so a manually
-  # installed copy is torn down with the rest of the kit.
+  # Automatic uninstall is retired; a manually installed copy remains
+  # user-owned and must be removed using its official instructions.
 }


### PR DESCRIPTION
## Root cause

Automatic uninstall was retired in #6 and the root Korean/English READMEs were aligned in #7, but platform guides, contributor policy, support guarantees, the project site, an older hero asset, and agent-step comments still described active teardown.

The legacy uninstall entrypoints are now non-destructive stubs and current CI no longer runs uninstall, so those surfaces were objectively inconsistent with shipped behavior.

## Changes

- Replace Linux and Windows uninstall command/group sections with the current non-destructive policy and manual-removal guidance.
- Correct Linux and Tier 1 CI guarantees to installation, verification, idempotency, Doctor, upgrade, and safety regressions.
- Remove retired uninstall groups/commands from contributor and versioning contracts.
- Correct the site and legacy hero CI/safety copy.
- Remove false comments claiming the kit deletes manually installed Antigravity.

No installer or legacy stub behavior changes.

## Tests

- `bash -n scripts/07-agents.sh linux/scripts/07-agents.sh`
- targeted search for stale active-uninstall and install→uninstall claims across the changed surfaces
- `git diff --check`

All passed locally.

Closes #19