### PR TITLE
feat(agents): retire gjc and lazycodex from supported setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
         run: tests/update-kit.sh
       - name: AI shell guard regression
         run: tests/ai-shell-guard.sh
+      - name: supported AI agents regression
+        run: bash tests/agents.sh
 
   lint-linux:
     name: linux shellcheck + syntax
@@ -80,7 +82,7 @@ jobs:
             mise which "$t" >/dev/null 2>&1 && echo "ok   mise:$t" || { echo "MISS mise:$t"; fail=1; }
           done
           command -v ast-grep >/dev/null 2>&1 && echo "ok   ast-grep" || { echo "MISS ast-grep"; fail=1; }
-          for t in gjc codex claude; do need "$t"; done
+          for t in codex claude; do need "$t"; done
           grep -q 'lazy-starter-kit:main' "$HOME/.zshrc" && echo "ok   zshrc block" || { echo "MISS zshrc block"; fail=1; }
           exit $fail
 
@@ -144,7 +146,7 @@ jobs:
             mise which "$t" >/dev/null 2>&1 && echo "ok   mise:$t" || { echo "MISS mise:$t"; fail=1; }
           done
           command -v ast-grep >/dev/null 2>&1 && echo "ok   ast-grep" || { echo "MISS ast-grep"; fail=1; }
-          for t in gjc codex claude; do need "$t"; done
+          for t in codex claude; do need "$t"; done
           grep -q 'lazy-starter-kit:main' "$HOME/.zshrc" && echo "ok   zshrc block" || { echo "MISS zshrc block"; fail=1; }
           exit $fail
 
@@ -180,7 +182,7 @@ jobs:
           set -uo pipefail
           export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.bun/bin:$HOME/.local/share/mise/shims:$PATH"
           fail=0
-          for t in rg fd bat fzf jq gh starship mise uv bun rustup zsh gjc codex claude; do
+          for t in rg fd bat fzf jq gh starship mise uv bun rustup zsh codex claude; do
             command -v "$t" >/dev/null 2>&1 && echo "ok   $t" || { echo "MISS $t"; fail=1; }
           done
           for tag in 'lazy-starter-kit:main' 'lazy-starter-kit:ohmyzsh'; do
@@ -199,7 +201,7 @@ jobs:
         run: |
           $fail = 0
           @(Get-ChildItem -Path windows,gui/windows -Recurse -Include *.ps1) + @(
-            Get-Item tests/windows-safe-remove.ps1,tests/windows-install-entrypoints.ps1
+            Get-Item tests/windows-safe-remove.ps1,tests/windows-install-entrypoints.ps1,tests/windows-agents.ps1
           ) | ForEach-Object {
             $tokens = $null; $errors = $null
             $null = [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$errors)
@@ -252,14 +254,13 @@ jobs:
           export PATH="$HOME/.local/share/mise/shims:$HOME/.bun/bin:$HOME/.local/bin:/opt/homebrew/opt/rustup/bin:$PATH"
           fail=0
           need() { command -v "$1" >/dev/null 2>&1 && echo "ok   $1" || { echo "MISS $1"; fail=1; }; }
-          for t in mise starship rg fd fzf bat gh colima zoxide node python go rustc gjc codex claude; do need "$t"; done
+          for t in mise starship rg fd fzf bat gh colima zoxide node python go rustc codex claude; do need "$t"; done
           echo "node:   $(node -v)"
           echo "python: $(python --version)"
           echo "go:     $(go version)"
           echo "codex:  $(codex --version 2>/dev/null | head -1 || echo '?')"
           test -d "$HOME/.oh-my-zsh" || { echo "MISS oh-my-zsh"; fail=1; }
           grep -q 'lazy-starter-kit:main' "$HOME/.zshrc" || { echo "MISS zshrc block"; fail=1; }
-          test -d "$HOME/.codex/plugins/cache/sisyphuslabs/omo" && echo "ok   lazycodex/omo" || echo "warn lazycodex/omo not found"
           exit $fail
 
       - name: install again (idempotency — "safe to re-run" is a test, not a claim)
@@ -292,6 +293,10 @@ jobs:
       - name: beginner installer entrypoints
         shell: powershell
         run: .\tests\windows-install-entrypoints.ps1
+
+      - name: supported AI agents regression (Windows PowerShell 5.1)
+        shell: powershell
+        run: .\tests\windows-agents.ps1
 
       - name: safe recursive delete regression (PowerShell 7)
         shell: pwsh
@@ -326,7 +331,7 @@ jobs:
           }
           & mise reshim 2>$null
           $env:Path += ";$env:LOCALAPPDATA\mise\shims;$env:USERPROFILE\.bun\bin;$env:USERPROFILE\.local\bin"
-          foreach ($t in 'gjc','codex','claude') {
+          foreach ($t in 'codex','claude') {
             if (Get-Command $t -ErrorAction SilentlyContinue) { Write-Host "ok   $t" }
             else { Write-Host "MISS $t"; $fail = 1 }
           }

--- a/gui/macos/main.swift
+++ b/gui/macos/main.swift
@@ -445,7 +445,7 @@ private final class InstallerController: NSObject, NSApplicationDelegate, NSWind
     }
     runtimesChoice.toolTip = "Node.js, Python, Go, Rust와 버전 관리자"
     dockerChoice.toolTip = "Colima, Docker CLI, Compose와 Buildx"
-    agentsChoice.toolTip = "Claude Code, Codex, gajae-code와 lazycodex"
+    agentsChoice.toolTip = "Claude Code, Codex"
     applyProfilePlan(profilePlans[0])
 
     let componentChoices = NSStackView(
@@ -841,7 +841,7 @@ private final class InstallerController: NSObject, NSApplicationDelegate, NSWind
       lines.append("Docker: Colima · Docker CLI · Compose · Buildx")
     }
     if agentsChoice.state == .on {
-      lines.append("AI 에이전트: Claude Code · Codex · gajae-code · lazycodex")
+      lines.append("AI 에이전트: Claude Code · Codex")
     }
     let details = lines.joined(separator: "\n")
     profileDetails.stringValue = details

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 #
 # lazy-starter-kit — install a complete macOS dev environment from scratch.
 # From nothing → Xcode CLT, Homebrew, runtimes, shell, Docker, AI agents
-# (Claude Code + gajae-code + codex + lazycodex).
+# (Claude Code + codex; Hermes opt-in).
 #
 # Usage:
 #   ./install.sh [options]
@@ -186,7 +186,7 @@ doctor() {
   _doctor_runtime go     runtimes
   _doctor_tool rustc runtimes
   _doctor_tool zsh   prereqs
-  for t in gjc codex claude; do
+  for t in codex claude; do
     _doctor_tool "$t" agents
   done
 

--- a/linux/install.sh
+++ b/linux/install.sh
@@ -2,7 +2,7 @@
 #
 # lazy-starter-kit — install a complete Linux dev environment from scratch.
 # From a fresh box → build tools, CLI, runtimes, shell, Docker, AI agents
-# (Claude Code + gajae-code + codex + lazycodex).
+# (Claude Code + codex; Hermes opt-in).
 #
 # Usage:
 #   ./install.sh [options]
@@ -153,7 +153,7 @@ doctor() {
   _doctor_runtime node   runtimes
   _doctor_runtime python runtimes
   _doctor_runtime go     runtimes
-  for t in gjc codex claude; do
+  for t in codex claude; do
     _doctor_tool "$t" agents
   done
 

--- a/linux/scripts/07-agents.sh
+++ b/linux/scripts/07-agents.sh
@@ -1,23 +1,11 @@
 #!/usr/bin/env bash
-# 07-agents.sh — AI coding agents: gajae-code (gjc), codex, lazycodex (OmO), Claude Code
+# 07-agents.sh — AI coding agents: codex, Claude Code, opt-in Hermes
 
 step_agents() {
-  step "AI agents: gajae-code + codex + lazycodex + Claude Code"
+  step "AI agents: codex + Claude Code"
   load_local_bins
   load_mise
-  export PATH="$HOME/.bun/bin:$PATH"   # bun global bins (gjc) live here
-
-  # --- gajae-code (gjc) via bun -----------------------------------------
-  if have bun; then
-    if have gjc; then
-      ok "gajae-code present (gjc $(gjc --version 2>/dev/null | head -1))"
-    else
-      info "Installing gajae-code (bun add -g gajae-code)…"
-      run bun add -g gajae-code
-    fi
-  else
-    warn "bun not found — skipping gajae-code (install bun via the 'packages' step)"
-  fi
+  export PATH="$HOME/.bun/bin:$PATH"   # bun global executables live here
 
   # --- Claude Code (Anthropic) ------------------------------------------
   # Official installer drops the `claude` binary into ~/.local/bin and then
@@ -42,13 +30,12 @@ step_agents() {
     rm -f "$cc_tmp"
   fi
 
-  # --- codex (base harness that lazycodex extends) ----------------------
+  # --- codex -----------------------------------------------------------
   if ! have npm; then
     if [[ "$DRY_RUN" == "1" ]]; then
       info "[dry-run] npm install -g @openai/codex"
-      info "[dry-run] npx --yes lazycodex-ai install"
     else
-      warn "npm not found — skipping codex + lazycodex (run the 'runtimes' step first)"
+      warn "npm not found — skipping codex (run the 'runtimes' step first)"
     fi
     return 0
   fi
@@ -60,20 +47,6 @@ step_agents() {
     # mise-managed node needs a reshim so the `codex` shim appears on PATH
     have mise && run mise reshim
   fi
-
-  # --- lazycodex (OmO agent harness for codex) --------------------------
-  # No global install by design — always run via npx.
-  if [[ "$DRY_RUN" == "1" ]]; then
-    info "[dry-run] npx --yes lazycodex-ai install"
-  elif is_tty && [[ "$ASSUME_YES" != "1" ]]; then
-    info "Installing lazycodex (npx lazycodex-ai install)…"
-    npx --yes lazycodex-ai install || warn "lazycodex installer did not complete"
-  else
-    info "Installing lazycodex (non-interactive, autonomous)…"
-    npx --yes lazycodex-ai install --no-tui --codex-autonomous || \
-      warn "lazycodex installer did not complete"
-  fi
-  info "lazycodex: on first 'codex' launch, APPROVE the omo hooks in the startup review."
 
   if have node; then
     if [[ "$DRY_RUN" == "1" ]]; then
@@ -119,6 +92,4 @@ step_agents() {
   # Gemini CLI's closed-source successor (`agy`) has a small free tier and its
   # own account flow, so it is a manual one-liner documented in the README
   # next to Grok Build:  curl -fsSL https://antigravity.google/cli/install.sh | bash
-  # uninstall.sh still removes ~/.local/bin/agy when present, so a manually
-  # installed copy is torn down with the rest of the kit.
 }

--- a/scripts/07-agents.sh
+++ b/scripts/07-agents.sh
@@ -1,27 +1,15 @@
 #!/usr/bin/env bash
-# 07-agents.sh — AI coding agents: gajae-code (gjc), codex, lazycodex (OmO), Claude Code
+# 07-agents.sh — AI coding agents: codex, Claude Code, opt-in Hermes
 
 step_agents() {
-  step "AI agents: gajae-code + codex + lazycodex + Claude Code"
+  step "AI agents: codex + Claude Code"
   load_brew
   load_mise
-  export PATH="$HOME/.bun/bin:$PATH"   # bun global bins (gjc) live here
+  export PATH="$HOME/.bun/bin:$PATH"   # bun global executables live here
   # ~/.local/bin hosts claude (Claude Code) and hermes; exporting it up front
   # also makes the Hermes installer detect PATH and skip editing ~/.zshrc
   # (the kit's managed block owns that PATH entry instead).
   export PATH="$HOME/.local/bin:$PATH"
-
-  # --- gajae-code (gjc) via bun -----------------------------------------
-  if have bun; then
-    if have gjc; then
-      ok "gajae-code present (gjc $(gjc --version 2>/dev/null | head -1))"
-    else
-      info "Installing gajae-code (bun add -g gajae-code)…"
-      run bun add -g gajae-code
-    fi
-  else
-    warn "bun not found — skipping gajae-code (install bun via the 'brew' step)"
-  fi
 
   # --- Claude Code (Anthropic) ------------------------------------------
   # Official installer drops the `claude` binary into ~/.local/bin and then
@@ -46,13 +34,12 @@ step_agents() {
     rm -f "$cc_tmp"
   fi
 
-  # --- codex (base harness that lazycodex extends) ----------------------
+  # --- codex -----------------------------------------------------------
   if ! have npm; then
     if [[ "$DRY_RUN" == "1" ]]; then
       info "[dry-run] npm install -g @openai/codex"
-      info "[dry-run] npx --yes lazycodex-ai install"
     else
-      warn "npm not found — skipping codex + lazycodex (run the 'runtimes' step first)"
+      warn "npm not found — skipping codex (run the 'runtimes' step first)"
     fi
     return 0
   fi
@@ -64,20 +51,6 @@ step_agents() {
     # mise-managed node needs a reshim so the `codex` shim appears on PATH
     have mise && run mise reshim
   fi
-
-  # --- lazycodex (OmO agent harness for codex) --------------------------
-  # No global install by design — always run via npx.
-  if [[ "$DRY_RUN" == "1" ]]; then
-    info "[dry-run] npx --yes lazycodex-ai install"
-  elif is_tty && [[ "$ASSUME_YES" != "1" ]]; then
-    info "Installing lazycodex (npx lazycodex-ai install)…"
-    npx --yes lazycodex-ai install || warn "lazycodex installer did not complete"
-  else
-    info "Installing lazycodex (non-interactive, autonomous)…"
-    npx --yes lazycodex-ai install --no-tui --codex-autonomous || \
-      warn "lazycodex installer did not complete"
-  fi
-  info "lazycodex: on first 'codex' launch, APPROVE the omo hooks in the startup review."
 
   if have node; then
     if [[ "$DRY_RUN" == "1" ]]; then
@@ -123,6 +96,4 @@ step_agents() {
   # Gemini CLI's closed-source successor (`agy`) has a small free tier and its
   # own account flow, so it is a manual one-liner documented in the README
   # next to Grok Build:  curl -fsSL https://antigravity.google/cli/install.sh | bash
-  # uninstall.sh still removes ~/.local/bin/agy when present, so a manually
-  # installed copy is torn down with the rest of the kit.
 }

--- a/tests/agents.sh
+++ b/tests/agents.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+# shellcheck source=lib/common.sh
+source "$REPO_ROOT/lib/common.sh"
+NODE_BIN="$(command -v node)"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+TMP_BASE="$REPO_ROOT/.tmp-tests"
+[[ ! -L "$TMP_BASE" ]] || fail 'fixture base must not be a symlink'
+mkdir -p "$TMP_BASE"
+[[ "$(cd "$TMP_BASE" && pwd -P)" == "$TMP_BASE" ]] || fail 'fixture base escapes worktree'
+WORK="$(mktemp -d "$TMP_BASE/agents.XXXXXX")"
+OWNER_TOKEN="agents:$$:$RANDOM:$RANDOM"
+readonly REPO_ROOT TMP_BASE WORK OWNER_TOKEN
+printf '%s\n' "$OWNER_TOKEN" > "$WORK/.agents-owner"
+
+validate_fixture_root() {
+  local candidate="$1"
+  [[ "$candidate" == "$WORK" && "$candidate" == "$TMP_BASE"/agents.* \
+    && "$TMP_BASE" == "$REPO_ROOT/.tmp-tests" \
+    && ! -L "$TMP_BASE" && ! -L "$candidate" && -d "$candidate" \
+    && ! -L "$candidate/.agents-owner" && -f "$candidate/.agents-owner" ]] || return 1
+  [[ "$(cd "$candidate" && pwd -P)" == "$candidate" ]] || return 1
+  printf '%s\n' "$OWNER_TOKEN" | cmp -s - "$candidate/.agents-owner"
+}
+cleanup() {
+  local status=$?
+  validate_fixture_root "$WORK" || {
+    printf 'FAIL: refusing cleanup: fixture boundary or ownership changed: %s\n' "$WORK" >&2
+    return 1
+  }
+  printf 'cleanup: safe_rm_rf_under "%s" "%s"\n' "$TMP_BASE" "$WORK"
+  DRY_RUN=0 safe_rm_rf_under "$TMP_BASE" "$WORK" || return 1
+  return "$status"
+}
+trap cleanup EXIT
+validate_fixture_root "$WORK" || fail 'invalid fixture ownership'
+for boundary in "$REPO_ROOT" "$TMP_BASE" "${HOME:-/}"; do
+  if validate_fixture_root "$boundary"; then fail "accepted non-fixture boundary: $boundary"; fi
+done
+mkdir "$WORK/runner-home" "$WORK/tmp"
+export HOME="$WORK/runner-home" USERPROFILE="$WORK/runner-home"
+export TMPDIR="$WORK/tmp" TMP="$WORK/tmp" TEMP="$WORK/tmp"
+unset BASH_ENV ENV
+printf 'fixtures: root=%s HOME=%s USERPROFILE=%s TMPDIR=%s\n' "$WORK" "$HOME" "$USERPROFILE" "$TMPDIR"
+
+run_case() (
+  platform="$1" mode="$2"
+  ROOT="$REPO_ROOT"
+  [[ "$platform" != linux ]] || ROOT="$REPO_ROOT/linux"
+  validate_fixture_root "$WORK" || fail 'invalid fixture boundary before agent step'
+  export HOME="$WORK/$platform-$mode" USERPROFILE="$WORK/$platform-$mode"
+  export TRACE="$WORK/$platform-$mode.trace"
+  export PATH=/usr/bin:/bin DRY_RUN=0 ASSUME_YES=1 HERMES=0
+  case "$mode" in dry|dry-no-npm|hermes-dry) DRY_RUN=1 ;; esac
+  case "$mode" in hermes|hermes-installed|hermes-dry) HERMES=1 ;; esac
+  mkdir "$HOME"
+  printf 'fixture: %s/%s HOME=%s USERPROFILE=%s TMPDIR=%s\n' "$platform" "$mode" "$HOME" "$USERPROFILE" "$TMPDIR"
+  : > "$TRACE"
+
+  # Existing legacy binaries, configuration and data are never migration targets.
+  sentinels=(
+    .bun/bin/gjc .local/bin/lazycodex
+    .gajae/config.json .config/gajae-code/config.json .gjc/session.json
+    .lazycodex/config.json .codex/config.toml .codex/sessions/sentinel
+    .codex/plugins/cache/sisyphuslabs/omo/sentinel
+  )
+  for file in "${sentinels[@]}"; do
+    mkdir -p "$(dirname "$HOME/$file")"
+    printf 'user-owned:%s\n' "$file" > "$HOME/$file"
+  done
+  chmod +x "$HOME/.bun/bin/gjc" "$HOME/.local/bin/lazycodex"
+  mkdir -p "$HOME/.claude"
+  printf '%s\n' '{"userSentinel":true,"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"user-owned-hook"}]}]}}' \
+    > "$HOME/.claude/settings.json"
+  cp "$HOME/.claude/settings.json" "$HOME/.codex/hooks.json"
+
+  record() { printf '%s\n' "$*" >> "$TRACE"; }
+  load_brew() { :; }
+  load_local_bins() { export PATH="$HOME/.local/bin:$PATH"; }
+  load_mise() { :; }
+  have() {
+    case "$1" in
+      bun|node|mise) return 0 ;;
+      npm) [[ "$mode" != no-npm && "$mode" != dry-no-npm ]] ;;
+      claude|codex) [[ "$mode" == installed || "$mode" == hermes-installed ]] ;;
+      hermes) [[ "$mode" == hermes-installed ]] ;;
+      gjc|lazycodex) record "probe $1"; [[ "$mode" == installed ]] ;;
+      *) return 1 ;;
+    esac
+  }
+  # All package-manager and legacy calls are intercepted, including RED runs.
+  bun() { record "bun $*"; }
+  npx() { record "npx $*"; }
+  gjc() { record "gjc $*"; }
+  lazycodex() { record "lazycodex $*"; }
+  npm() { record "npm $*"; }
+  mise() { record "mise $*"; }
+  claude() { record "claude $*"; printf 'fixture-claude\n'; }
+  codex() { record "codex $*"; printf 'fixture-codex\n'; }
+  hermes() { record "hermes $*"; printf 'fixture-hermes\n'; }
+  node() {
+    record "node $*"
+    "$NODE_BIN" "$@"
+  }
+  curl() {
+    [[ "$#" == 4 && "$1" == -fsSL && "$3" == -o ]] || return 91
+    local agent
+    case "$2" in
+      https://claude.ai/install.sh) agent=claude ;;
+      https://hermes-agent.nousresearch.com/install.sh) agent=hermes ;;
+      *) record "unexpected download $2"; return 92 ;;
+    esac
+    record "download $agent"
+    # Exercise the real download/shebang/bash path, without network or installs.
+    printf '#!/usr/bin/env bash\nprintf "installer %s %%s\\n" "$*" >> "$TRACE"\n' "$agent" > "$4"
+  }
+
+  # shellcheck disable=SC1090
+  source "$ROOT/scripts/07-agents.sh"
+  step_agents > "$WORK/$platform-$mode.output" 2>&1
+
+  if grep -E 'gjc|gajae-code|lazycodex|^npx |^bun ' "$TRACE"; then
+    fail "$platform/$mode invoked a legacy agent"
+  fi
+  expected="$WORK/$platform-$mode.expected"
+  : > "$expected"
+  case "$mode" in
+    installed|hermes-installed) printf '%s\n' 'claude --version' 'codex --version' >> "$expected" ;;
+    fresh|hermes)
+      printf '%s\n' 'download claude' 'installer claude ' 'npm install -g @openai/codex' 'mise reshim' >> "$expected" ;;
+    no-npm) printf '%s\n' 'download claude' 'installer claude ' >> "$expected" ;;
+  esac
+  guard="$ROOT/scripts/ai/install-shell-guard.js"
+  [[ "$platform" != linux ]] || guard="$ROOT/../scripts/ai/install-shell-guard.js"
+  case "$mode" in
+    no-npm|dry-no-npm) ;;
+    *) printf 'node %s --home %s%s\n' "$guard" "$HOME" "$( [[ "$DRY_RUN" != 1 ]] || printf ' --dry-run' )" >> "$expected" ;;
+  esac
+  case "$mode" in
+    hermes) printf '%s\n' 'download hermes' 'installer hermes --skip-setup' >> "$expected" ;;
+    hermes-installed) printf '%s\n' 'hermes --version' >> "$expected" ;;
+  esac
+  diff -u "$expected" "$TRACE" || fail "$platform/$mode command trace changed"
+
+  for file in "${sentinels[@]}"; do
+    printf 'user-owned:%s\n' "$file" | cmp -s - "$HOME/$file" \
+      || fail "$platform/$mode changed legacy sentinel $file"
+  done
+  [[ -x "$HOME/.bun/bin/gjc" && -x "$HOME/.local/bin/lazycodex" ]] \
+    || fail "$platform/$mode changed legacy executable permissions"
+
+  # Run the actual safety installer and inspect parsed hooks, not its prose.
+  "$NODE_BIN" - "$HOME" "$mode" <<'JS'
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const [home, mode] = process.argv.slice(2);
+const installsGuard = !['dry', 'dry-no-npm', 'no-npm', 'hermes-dry'].includes(mode);
+for (const file of ['.codex/hooks.json', '.claude/settings.json']) {
+  const config = JSON.parse(fs.readFileSync(path.join(home, file), 'utf8'));
+  assert.strictEqual(config.userSentinel, true);
+  const commands = config.hooks.PreToolUse.flatMap(group => group.hooks.map(hook => hook.command));
+  assert(commands.includes('user-owned-hook'));
+  assert.strictEqual(commands.filter(command => command.includes('shell-command-guard.js')).length, installsGuard ? 1 : 0);
+}
+assert.strictEqual(fs.existsSync(path.join(home, '.local/bin/lazy-safe-rm')), installsGuard);
+JS
+  printf 'ok: %s/%s\n' "$platform" "$mode"
+)
+
+doctor_case() (
+  local platform="$1"
+  ROOT="$REPO_ROOT"
+  [[ "$platform" != linux ]] || ROOT="$REPO_ROOT/linux"
+  validate_fixture_root "$WORK" || fail 'invalid fixture boundary before doctor'
+  export HOME="$WORK/$platform-doctor" USERPROFILE="$WORK/$platform-doctor"
+  export TRACE="$WORK/$platform-doctor.trace"
+  mkdir "$HOME"
+  printf 'fixture: %s/doctor HOME=%s USERPROFILE=%s TMPDIR=%s\n' "$platform" "$HOME" "$USERPROFILE" "$TMPDIR"
+  : > "$TRACE"
+  # Source the actual doctor function without executing bootstrap or preflight.
+  # Its probes are controlled so only an obsolete requirement can fail health.
+  source /dev/stdin <<< "$(awk '/^doctor\(\) \{/{copy=1} copy{print} copy && /^}/{exit}' "$ROOT/install.sh")"
+  cache_zsh_config_dir() { :; }
+  zsh_config_file() { printf '%s/%s\n' "$HOME" "$1"; }
+  brew_prefix() { printf '/fixture/brew\n'; }
+  load_mise() { :; }
+  _doctor_config() { :; }
+  _doctor_tool() {
+    [[ "$2" != agents ]] || printf '%s\n' "$1" >> "$TRACE"
+    case "$1" in gjc|lazycodex) _DOCTOR_MISSING=$((_DOCTOR_MISSING + 1)) ;; esac
+  }
+  _doctor_runtime() { :; }
+  export KIT_VERSION=fixture
+  local status=0
+  (doctor) > "$WORK/$platform-doctor.output" 2>&1 || status=$?
+  [[ "$status" == 0 ]] || fail "$platform doctor requires legacy tooling (exit $status)"
+  printf 'codex\nclaude\n' | diff -u - "$TRACE" || fail "$platform doctor agent roster changed"
+  printf 'ok: %s/doctor without legacy tools\n' "$platform"
+)
+
+failures=0
+for platform in macos linux; do
+  for mode in fresh installed dry dry-no-npm no-npm hermes hermes-installed hermes-dry; do
+    # A separate bash keeps errexit active inside each fixture, even while the
+    # parent collects failures to expose both platforms in a single RED run.
+    export REPO_ROOT NODE_BIN WORK TMP_BASE OWNER_TOKEN
+    export -f run_case fail validate_fixture_root
+    bash -c 'set -euo pipefail; source "$REPO_ROOT/lib/common.sh"; run_case "$@"' _ "$platform" "$mode" \
+      || failures=$((failures + 1))
+  done
+  doctor_case "$platform" || failures=$((failures + 1))
+done
+[[ "$failures" == 0 ]] || fail "$failures agent scenarios failed"
+printf 'ok: agent installation and doctor contracts (18 scenarios)\n'

--- a/tests/install-entrypoints.sh
+++ b/tests/install-entrypoints.sh
@@ -66,25 +66,34 @@ printf 'ok   macOS launcher normalizes its temporary checkout path\n'
 # Given an existing bootstrap checkout, when the requested ref cannot prove the
 # pinned commit or the checkout is dirty, then installation must fail closed.
 PINNED_COMMIT="$(git -C "$ROOT" rev-parse HEAD)"
+# Own the fetched ref: caller main may differ from HEAD or not exist at all.
+BOOTSTRAP_ORIGIN="$TMP/bootstrap-origin"
+git init --quiet "$BOOTSTRAP_ORIGIN"
+git -C "$BOOTSTRAP_ORIGIN" fetch --quiet --depth 1 "$ROOT" "$PINNED_COMMIT"
+git -C "$BOOTSTRAP_ORIGIN" checkout --quiet -b entrypoint-fixture FETCH_HEAD
 BOOTSTRAP_CHECKOUT="$TMP/bootstrap-checkout"
-git clone --quiet --no-hardlinks "$ROOT" "$BOOTSTRAP_CHECKOUT"
-if STARTER_KIT_REPO="$ROOT" \
+git clone --quiet --no-hardlinks --branch entrypoint-fixture "$BOOTSTRAP_ORIGIN" "$BOOTSTRAP_CHECKOUT"
+if STARTER_KIT_REPO="$BOOTSTRAP_ORIGIN" \
   STARTER_KIT_DIR="$BOOTSTRAP_CHECKOUT" \
-  STARTER_KIT_BRANCH=main \
+  STARTER_KIT_BRANCH=entrypoint-fixture \
   STARTER_KIT_COMMIT=0000000000000000000000000000000000000000 \
   bash -s -- --list < "$ROOT/install.sh" >/dev/null 2>&1
 then
   fail "bootstrap accepted a ref that did not match its pinned commit"
 fi
-STARTER_KIT_REPO="$ROOT" \
+[[ "$(git -C "$BOOTSTRAP_CHECKOUT" rev-parse FETCH_HEAD)" == "$PINNED_COMMIT" ]] \
+  || fail "wrong-pin rejection did not fetch the tested commit"
+STARTER_KIT_REPO="$BOOTSTRAP_ORIGIN" \
 STARTER_KIT_DIR="$BOOTSTRAP_CHECKOUT" \
-STARTER_KIT_BRANCH=main \
+STARTER_KIT_BRANCH=entrypoint-fixture \
 STARTER_KIT_COMMIT="$PINNED_COMMIT" \
   bash -s -- --list < "$ROOT/install.sh" >/dev/null
+[[ "$(git -C "$BOOTSTRAP_CHECKOUT" rev-parse HEAD)" == "$PINNED_COMMIT" ]] \
+  || fail "bootstrap did not check out the tested commit"
 printf 'local change\n' > "$BOOTSTRAP_CHECKOUT/untracked-change"
-if STARTER_KIT_REPO="$ROOT" \
+if STARTER_KIT_REPO="$BOOTSTRAP_ORIGIN" \
   STARTER_KIT_DIR="$BOOTSTRAP_CHECKOUT" \
-  STARTER_KIT_BRANCH=main \
+  STARTER_KIT_BRANCH=entrypoint-fixture \
   STARTER_KIT_COMMIT="$PINNED_COMMIT" \
   bash -s -- --list < "$ROOT/install.sh" >/dev/null 2>&1
 then

--- a/tests/windows-agents.ps1
+++ b/tests/windows-agents.ps1
@@ -1,0 +1,244 @@
+#requires -Version 5.1
+$ErrorActionPreference = 'Stop'
+$Root = Join-Path $PSScriptRoot '..\windows'
+. (Join-Path $Root 'scripts\lib.ps1')
+. (Join-Path $Root 'scripts\07-agents.ps1')
+
+function Assert-Equal($Actual, $Expected, [string]$Label) {
+  if ($Actual -cne $Expected) {
+    throw "FAIL: ${Label}: expected [$Expected], got [$Actual]"
+  }
+}
+
+# Mock command boundaries, not Step-Agents or its real invocation helpers.
+function Record-Command([string]$Name, [string[]]$Arguments) {
+  $script:Calls.Add((@($Name) + @($Arguments) -join ' '))
+  $global:LASTEXITCODE = 0
+}
+function npm { Record-Command 'npm' $args }
+# PowerShell consumes the -- separator when binding a function mock.
+function mise { Record-Command 'mise' $args }
+function bun { Record-Command 'bun' $args }
+function npx { Record-Command 'npx' $args }
+function node { Record-Command 'node' $args }
+function gjc { Record-Command 'gjc' $args; 'legacy-version' }
+function codex { Record-Command 'codex' $args; 'codex-version' }
+function claude { Record-Command 'claude' $args; 'claude-version' }
+function Update-SessionPath {}
+function Test-HasCommand([string]$Name) {
+  $script:Probes.Add($Name)
+  return $script:Available -contains $Name
+}
+function Invoke-RestMethod([string]$Uri) {
+  Record-Command 'Invoke-RestMethod' @($Uri)
+  return 'Invoke-ClaudeInstallerMock'
+}
+function Invoke-ClaudeInstallerMock {
+  Record-Command 'claude-native-install' @()
+  $script:Available += 'claude'
+}
+
+$worktree = [IO.Path]::GetFullPath((Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).ProviderPath)
+$fixtureBase = Join-Path $worktree '.tmp-tests'
+$fixtureRoot = Join-Path $fixtureBase ("windows-agents-{0}" -f [Guid]::NewGuid().ToString('N'))
+$ownerToken = [Guid]::NewGuid().ToString('N')
+$ownerPath = Join-Path $fixtureRoot '.windows-agents-owner'
+
+function Assert-FixtureBoundary([string]$Path) {
+  $full = [IO.Path]::GetFullPath($Path)
+  $prefix = $fixtureBase + [IO.Path]::DirectorySeparatorChar
+  if (-not $full.StartsWith($prefix, [StringComparison]::Ordinal)) {
+    throw "Fixture path must be strictly below ${fixtureBase}: $Path"
+  }
+  # Reject links in every existing ancestor before writing any fixture data.
+  $cursor = $full
+  while ($cursor) {
+    if (Test-Path -LiteralPath $cursor) {
+      if (((Get-Item -LiteralPath $cursor -Force).Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "Fixture path crosses a reparse point: $cursor"
+      }
+    }
+    if ($cursor -eq $worktree) { break }
+    $cursor = [IO.Path]::GetDirectoryName($cursor)
+  }
+  if ($cursor -ne $worktree) { throw "Fixture path escapes worktree: $Path" }
+}
+
+Assert-FixtureBoundary $fixtureRoot
+if (-not (Test-Path -LiteralPath $fixtureBase)) {
+  New-Item -ItemType Directory -Path $fixtureBase | Out-Null
+}
+# No -Force: an existing fixture is never adopted or overwritten.
+New-Item -ItemType Directory -Path $fixtureRoot | Out-Null
+Assert-FixtureBoundary $ownerPath
+[IO.File]::WriteAllText($ownerPath, $ownerToken)
+$tempRoot = Join-Path $fixtureRoot 'home'
+$doctorHome = Join-Path $fixtureRoot 'doctor-home'
+$fixtureTemp = Join-Path $fixtureRoot 'temp'
+foreach ($path in @($tempRoot, $doctorHome, $fixtureTemp)) {
+  Assert-FixtureBoundary $path
+  Assert-Equal ([IO.File]::ReadAllText($ownerPath)) $ownerToken 'fixture ownership'
+  New-Item -ItemType Directory -Path $path | Out-Null
+}
+$savedEnvironment = @{}
+foreach ($name in @('HOME', 'USERPROFILE', 'APPDATA', 'LOCALAPPDATA', 'TMPDIR', 'TMP', 'TEMP')) {
+  $savedEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+}
+$savedHome = $HOME
+try {
+  Set-Variable -Name HOME -Scope Script -Value $tempRoot -Force
+  $env:HOME = $tempRoot
+  $env:USERPROFILE = $tempRoot
+  $env:APPDATA = Join-Path $tempRoot 'AppData\Roaming'
+  $env:LOCALAPPDATA = Join-Path $tempRoot 'AppData\Local'
+  $env:TMPDIR = $fixtureTemp
+  $env:TMP = $fixtureTemp
+  $env:TEMP = $fixtureTemp
+  Write-Host "Fixture boundary: $fixtureRoot; owner marker: $ownerPath"
+  Write-Host "HOME/USERPROFILE: $tempRoot; doctor home: $doctorHome; temp: $fixtureTemp"
+  # Legacy executables, config, plugins, and session data must be left alone.
+  $sentinels = @(
+    '.bun/bin/gjc.exe', '.bun/install/global/node_modules/gajae-code/package.json',
+    '.gjc/config.json', '.gjc/sessions/keep.json',
+    '.local/bin/lazycodex', 'AppData/Roaming/npm/lazycodex.cmd',
+    '.codex/config.toml', '.codex/hooks.json',
+    '.codex/plugins/cache/sisyphuslabs/omo/keep.json',
+    '.codex/sessions/keep.jsonl', '.claude/settings.json'
+  )
+  $hashes = @{}
+  foreach ($relative in $sentinels) {
+    $path = Join-Path $tempRoot $relative
+    Assert-FixtureBoundary $path
+    New-Item -ItemType Directory -Path (Split-Path -Parent $path) -Force | Out-Null
+    [IO.File]::WriteAllText($path, "legacy sentinel: $relative`n")
+    $hashes[$relative] = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash
+  }
+  $guard = Join-Path (Split-Path -Parent $Root) 'scripts\ai\install-shell-guard.js'
+  if (-not (Test-Path -LiteralPath $guard)) { throw 'Missing real guard installer' }
+  $guardCommand = "node $guard --home $tempRoot"
+  $nativeClaude = @(
+    'Invoke-RestMethod https://claude.ai/install.ps1',
+    'claude-native-install', 'claude --version'
+  )
+  $cases = @(
+    @{ Name = 'fresh npm'; Available = @('bun', 'npm', 'node'); Dry = $false;
+      Expected = @('npm install -g @openai/codex') + $nativeClaude + @($guardCommand) },
+    @{ Name = 'fresh mise'; Available = @('bun', 'mise', 'node'); Dry = $false;
+      Expected = @('mise exec npm install -g @openai/codex', 'mise reshim') + $nativeClaude + @($guardCommand) },
+    @{ Name = 'existing agents and legacy tools'; Available = @('bun', 'npm', 'mise', 'node', 'gjc', 'lazycodex', 'codex', 'claude'); Dry = $false;
+      Expected = @('codex --version', 'claude --version', $guardCommand) },
+    @{ Name = 'fresh dry-run'; Available = @('bun', 'npm', 'node'); Dry = $true;
+      Expected = @("$guardCommand --dry-run") },
+    @{ Name = 'existing dry-run'; Available = @('bun', 'npm', 'node', 'gjc', 'lazycodex', 'codex', 'claude'); Dry = $true;
+      Expected = @('codex --version', 'claude --version', "$guardCommand --dry-run") }
+  )
+  $failures = New-Object 'System.Collections.Generic.List[string]'
+  foreach ($case in $cases) {
+    $script:Calls = New-Object 'System.Collections.Generic.List[string]'
+    $script:Probes = New-Object 'System.Collections.Generic.List[string]'
+    $script:Available = $case.Available
+    $script:DryRun = $case.Dry
+    try {
+      Step-Agents
+      Assert-Equal ($script:Calls -join ' | ') ($case.Expected -join ' | ') $case.Name
+      Assert-Equal (@($script:Probes | Where-Object { $_ -in @('gjc', 'lazycodex') }).Count) 0 'no legacy command probes'
+      foreach ($relative in $sentinels) {
+        $path = Join-Path $tempRoot $relative
+        Assert-Equal (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash $hashes[$relative] "preserved $relative"
+      }
+      Assert-Equal (@(Get-ChildItem -LiteralPath $tempRoot -File -Recurse -Force).Count) $sentinels.Count 'no extra home files'
+      Write-Host "PASS: $($case.Name); legacy sentinels unchanged"
+    } catch {
+      $failures.Add("$($case.Name): $($_.Exception.Message)")
+    }
+  }
+
+  # Load the actual doctor function without running installer preflight/bootstrap.
+  $tokens = $null
+  $parseErrors = $null
+  $ast = [Management.Automation.Language.Parser]::ParseFile(
+    (Join-Path $Root 'install.ps1'), [ref]$tokens, [ref]$parseErrors)
+  Assert-Equal $parseErrors.Count 0 'installer parses'
+  $doctor = $ast.Find({
+    param($entry)
+    $entry -is [Management.Automation.Language.FunctionDefinitionAst] -and
+      $entry.Name -eq 'Invoke-Doctor'
+  }, $true)
+  if (-not $doctor) { throw 'Invoke-Doctor not found' }
+  . ([scriptblock]::Create($doctor.Extent.Text))
+  & {
+    $KitVersion = 'test'
+    $HomeDir = $tempRoot
+    $required = @('git', 'gh', 'jq', 'rg', 'fd', 'bat', 'fzf', 'starship',
+      'mise', 'uv', 'rustup', 'bun', 'codex', 'claude')
+    function Get-Command {
+      param([string]$Name, [string]$ErrorAction)
+      $script:Probes.Add($Name)
+      if ($required -contains $Name -and $Name -ne $missingTool) {
+        [pscustomobject]@{ Name = $Name }
+      }
+    }
+    function Invoke-NativeSilently {
+      param([string]$Exe, [string[]]$Arguments)
+      $global:LASTEXITCODE = 0
+      'mock-version-or-runtime-path'
+    }
+    function Get-AllHostsProfilePaths { @() }
+    # Doctor probes a clean home: legacy binaries must not mask a requirement.
+    $HomeDir = $doctorHome
+    Set-Variable -Name HOME -Scope Local -Value $doctorHome -Force
+    $env:HOME = $doctorHome
+    $env:USERPROFILE = $doctorHome
+    $env:APPDATA = Join-Path $env:USERPROFILE 'AppData\Roaming'
+    $env:LOCALAPPDATA = Join-Path $env:USERPROFILE 'AppData\Local'
+    foreach ($missingTool in @('', 'codex', 'claude')) {
+      $script:Probes.Clear()
+      try {
+        $expected = if ($missingTool) { 1 } else { 0 }
+        Assert-Equal (Invoke-Doctor) $expected "doctor missing=[$missingTool]"
+        Assert-Equal (@($script:Probes | Where-Object { $_ -in @('gjc', 'lazycodex') }).Count) 0 'doctor ignores legacy tools'
+        Write-Host "PASS: doctor missing=[$missingTool]"
+      } catch {
+        $failures.Add("doctor missing=[$missingTool]: $($_.Exception.Message)")
+      }
+    }
+  }
+  Assert-FixtureBoundary $ownerPath
+  Assert-Equal ([IO.File]::ReadAllText($ownerPath)) $ownerToken 'fixture ownership retained'
+  if ($failures.Count) { throw ($failures -join "`n") }
+  Write-Host 'PASS: Windows agents regression'
+} finally {
+  try {
+    # Cleanup authority comes from this fresh root and its independent token,
+    # never from HOME/USERPROFILE or the machine's temporary-directory setting.
+    Assert-FixtureBoundary $ownerPath
+    Assert-Equal ([IO.File]::ReadAllText($ownerPath)) $ownerToken 'cleanup ownership'
+    # Inspect one directory at a time, rejecting links before descending.
+    $pending = New-Object 'System.Collections.Generic.Stack[string]'
+    $pending.Push($fixtureRoot)
+    while ($pending.Count) {
+      $directory = $pending.Pop()
+      Assert-FixtureBoundary $directory
+      foreach ($item in (Get-ChildItem -LiteralPath $directory -Force)) {
+        Assert-FixtureBoundary $item.FullName
+        if ($item.PSIsContainer) { $pending.Push($item.FullName) }
+      }
+    }
+    if (Test-IsWindows) {
+      $script:DryRun = $false
+      Remove-KitTree -AllowedRoot $fixtureBase -Path $fixtureRoot
+      Assert-Equal (Test-Path -LiteralPath $fixtureRoot) $false 'owned fixture cleanup'
+      Write-Host "Cleaned owned fixture through Remove-KitTree: $fixtureRoot"
+    } else {
+      # The existing helper requires native Windows drive paths. Do not widen
+      # it or substitute another recursive deleter for portable Docker tests.
+      Write-Host "Retained owned fixture: $fixtureRoot (Remove-KitTree requires Windows drive paths)"
+    }
+  } finally {
+    # No cleanup runs after restoring the caller's real environment.
+    foreach ($name in $savedEnvironment.Keys) {
+      [Environment]::SetEnvironmentVariable($name, $savedEnvironment[$name], 'Process')
+    }
+    Set-Variable -Name HOME -Scope Script -Value $savedHome -Force
+  }
+}

--- a/tests/zdotdir-existing-home.sh
+++ b/tests/zdotdir-existing-home.sh
@@ -222,15 +222,39 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     || fail "doctor: active ZDOTDIR/.zprofile was reported missing"
 fi
 
-env -u ZDOTDIR HOME="$zshenv_home" SHELL=/bin/zsh \
+uninstall_snapshot="$TMP_ROOT/uninstall-before"
+uninstall_files=(.config/zsh/.zshrc .config/zsh/.zprofile .zshrc .zshenv .config/starship.toml)
+for file in "${uninstall_files[@]}"; do
+  mkdir -p "$uninstall_snapshot/$(dirname "$file")"
+  cp -L "$zshenv_home/$file" "$uninstall_snapshot/$file"
+  if [[ -L "$zshenv_home/$file" ]]; then
+    readlink "$zshenv_home/$file" > "$uninstall_snapshot/$file.link"
+  fi
+done
+
+expected_uninstall_status=1
+[[ "$platform_root" != "$ROOT/linux" ]] || expected_uninstall_status=2
+if env -u ZDOTDIR HOME="$zshenv_home" SHELL=/bin/zsh \
   PATH="$zshenv_home/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
-  /bin/bash "$platform_root/uninstall.sh" --only shell --yes >/dev/null 2>&1
-if grep -qsF '# >>> lazy-starter-kit:' "$zshenv_zdot/.zshrc"; then
-  fail "uninstall: managed blocks remained in the active ZDOTDIR/.zshrc"
+  /bin/bash "$platform_root/uninstall.sh" --only shell --yes >/dev/null 2>&1; then
+  fail "uninstall: automatic uninstall unexpectedly succeeded"
+else
+  uninstall_status=$?
 fi
-if [[ "$(uname -s)" == "Darwin" ]] \
-  && grep -qsF '# >>> lazy-starter-kit:' "$zshenv_zdot/.zprofile"; then
-  fail "uninstall: managed blocks remained in the active ZDOTDIR/.zprofile"
-fi
+[[ "$uninstall_status" -eq "$expected_uninstall_status" ]] \
+  || fail "uninstall: expected refusal status $expected_uninstall_status, got $uninstall_status"
+for file in "${uninstall_files[@]}"; do
+  cmp -s "$uninstall_snapshot/$file" "$zshenv_home/$file" \
+    || fail "uninstall: changed or removed $file"
+  if [[ -f "$uninstall_snapshot/$file.link" ]]; then
+    [[ -L "$zshenv_home/$file" ]] \
+      || fail "uninstall: replaced $file symlink"
+    cmp -s "$uninstall_snapshot/$file.link" <(readlink "$zshenv_home/$file") \
+      || fail "uninstall: changed $file symlink target"
+  else
+    [[ ! -L "$zshenv_home/$file" ]] \
+      || fail "uninstall: replaced $file with a symlink"
+  fi
+done
 
 printf 'ok: install targets the Zsh startup directory used by existing users\n'

--- a/windows/install.ps1
+++ b/windows/install.ps1
@@ -5,7 +5,7 @@
 
 .DESCRIPTION
   From a fresh machine -> winget packages, runtimes, PowerShell profile, Docker,
-  and AI coding agents (gajae-code + codex + lazycodex).
+  and AI coding agents (codex + Claude Code).
 
   Steps (in order): prereqs packages runtimes shell docker git agents wsl
 
@@ -337,7 +337,7 @@ function Invoke-Doctor {
     git = 'packages'; gh = 'packages'; jq = 'packages'; rg = 'packages'
     fd = 'packages'; bat = 'packages'; fzf = 'packages'; starship = 'packages'
     mise = 'packages'; uv = 'packages'; rustup = 'packages'; bun = 'packages'
-    gjc = 'agents'; codex = 'agents'; claude = 'agents'
+    codex = 'agents'; claude = 'agents'
   }
 
   # user-local install dirs to probe when a tool isn't resolvable on PATH.

--- a/windows/scripts/07-agents.ps1
+++ b/windows/scripts/07-agents.ps1
@@ -1,31 +1,17 @@
-# 07-agents.ps1 -- AI coding agents: gajae-code (gjc), codex, lazycodex (OmO),
-# Claude Code (claude)
+# 07-agents.ps1 -- AI coding agents: codex, Claude Code (claude)
 
 function Step-Agents {
-  Write-Step "AI agents: gajae-code + codex + lazycodex + Claude Code"
+  Write-Step "AI agents: codex + Claude Code"
   Update-SessionPath
 
-  # --- gajae-code (gjc) via bun -----------------------------------------
-  if (Test-HasCommand bun) {
-    if (Test-HasCommand gjc) {
-      Write-Ok "gajae-code present (gjc $(Invoke-NativeSilently 'gjc' @('--version') | Select-Object -First 1))"
-    } else {
-      Write-Info "Installing gajae-code (bun add -g gajae-code)..."
-      Invoke-Run -Exe 'bun' -Arguments @('add', '-g', 'gajae-code') | Out-Null
-      Update-SessionPath
-    }
-  } else {
-    Write-Warn "bun not found -- skipping gajae-code (install bun via the 'packages' step)"
-  }
-
-  # --- codex (base harness that lazycodex extends) ----------------------
+  # --- codex via npm ---------------------------------------------------
   $haveNpm = Test-HasCommand npm
   if (-not $haveNpm -and (Test-HasCommand mise)) {
     # npm may only be reachable through mise's node shim
     $haveNpm = $true
   }
   if (-not $haveNpm) {
-    Write-Warn "npm not found -- skipping codex + lazycodex (run the 'runtimes' step first)"
+    Write-Warn "npm not found -- skipping codex (run the 'runtimes' step first)"
     return
   }
 
@@ -45,20 +31,6 @@ function Step-Agents {
     }
     Update-SessionPath
   }
-
-  # --- lazycodex (OmO harness for codex) -- always via npx ----------------
-  if ($script:DryRun) {
-    Write-Info "[dry-run] npx --yes lazycodex-ai install"
-  } elseif (-not [Console]::IsInputRedirected) {
-    Write-Info "Installing lazycodex (npx lazycodex-ai install)..."
-    & npx --yes lazycodex-ai install
-    if ($LASTEXITCODE -ne 0) { Write-Warn "lazycodex installer did not complete" }
-  } else {
-    Write-Info "Installing lazycodex (non-interactive, autonomous)..."
-    & npx --yes lazycodex-ai install --no-tui --codex-autonomous
-    if ($LASTEXITCODE -ne 0) { Write-Warn "lazycodex installer did not complete" }
-  }
-  Write-Info "lazycodex: on first 'codex' launch, APPROVE the omo hooks in the startup review."
 
   # --- Claude Code (claude) via the official installer ------------------
   # https://claude.ai/install.ps1 is non-interactive, works on WinPS 5.1+/7,
@@ -111,6 +83,4 @@ function Step-Agents {
   # Gemini CLI's closed-source successor (`agy`) has a small free tier and its
   # own account flow, so it is a manual one-liner documented in the README
   # next to Grok Build:  irm https://antigravity.google/cli/install.ps1 | iex
-  # uninstall.ps1 still removes %LOCALAPPDATA%\agy when present, so a manually
-  # installed copy is torn down with the rest of the kit.
 }


### PR DESCRIPTION
## Summary

- Stop installing or requiring gajae-code/gjc and lazycodex on macOS, Linux, and Windows.
- Keep Codex, Claude Code, optional Unix Hermes, and the independent shell safety hooks.
- Align the macOS agent roster and CI checks with the supported agents.
- Add deterministic tests of real agent/doctor functions, including preservation of existing legacy binaries, settings, plugins, and sessions.

## Safety

This change does not uninstall anything. Existing automatic-uninstall refusal remains in place.
Test HOME and temporary paths are fresh worktree descendants with ownership and boundary checks.
Windows portable verification uses a read-only repository mount and container-only writable temporary files; the real HOME is not mounted.

## Verification

- Unix agent/doctor regression: 18 cases pass.
- Windows agent regression: five installation cases and three doctor cases pass in PowerShell 7 on a network-disabled Linux container.
- Warning-level ShellCheck, syntax, shell-guard regression, and release-signing contract pass.
- Universal macOS build, GUI selftest, snapshot, and harmless local-payload exercise passed in independent verification.
- Full macOS entrypoint suite passes directly on the feature worktree after making the bootstrap origin an owned fixture pinned to tested HEAD. A detached/shallow fixture without local `main` also passes the bootstrap checks. Wrong-pin and dirty-checkout rejection remain covered.
- ZDOTDIR regression now verifies the retired uninstaller's refusal and byte/link preservation, instead of expecting deleted configuration. The full regression passes.
- Initial CI passed native Windows install/verify, the new PowerShell 5.1 agent regression, all Linux distro installs, and the Linux upgrade path. It identified the two existing fixture defects above; both are fixed in separate test-only commits and current CI is running again.
- Native WinForms interaction and signing/notarization are not claimed.

## Scope and merge gate

Phase 1 of three sequential PRs. Recommended installation/profile onboarding belongs to Phase 2; active README and landing-page guidance belongs to Phase 3.
The original dirty checkout remains untouched.

Do not merge until the final ultrabrain review approves this exact revision and validation results are recorded.
