### PR TITLE
feat(setup): add recommended installation and first-use guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
         run: tests/ai-shell-guard.sh
       - name: supported AI agents regression
         run: bash tests/agents.sh
+      - name: installation profiles regression
+        run: bash tests/profiles.sh
 
   lint-linux:
     name: linux shellcheck + syntax
@@ -201,7 +203,7 @@ jobs:
         run: |
           $fail = 0
           @(Get-ChildItem -Path windows,gui/windows -Recurse -Include *.ps1) + @(
-            Get-Item tests/windows-safe-remove.ps1,tests/windows-install-entrypoints.ps1,tests/windows-agents.ps1
+            Get-Item tests/windows-safe-remove.ps1,tests/windows-install-entrypoints.ps1,tests/windows-agents.ps1,tests/windows-profiles.ps1
           ) | ForEach-Object {
             $tokens = $null; $errors = $null
             $null = [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$errors)
@@ -297,6 +299,10 @@ jobs:
       - name: supported AI agents regression (Windows PowerShell 5.1)
         shell: powershell
         run: .\tests\windows-agents.ps1
+
+      - name: installation profiles regression (Windows PowerShell 5.1)
+        shell: powershell
+        run: .\tests\windows-profiles.ps1
 
       - name: safe recursive delete regression (PowerShell 7)
         shell: pwsh

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -92,13 +92,14 @@ Custom vector `NSImage`; rendered at runtime and packaged as `AppIcon.icns`. It 
 
 ### Profile selector
 
-Native `NSPopUpButton` with `slider.horizontal.3` context icon and three localized presets:
+Native `NSPopUpButton` with `slider.horizontal.3` context icon and four localized presets:
 
-- 전체 설치 — complete environment
+- 추천 설치 — initial selection: `prereqs,brew,runtimes,shell,git,agents`; supported Claude Code and Codex, without Docker
+- 전체 설치 — complete environment (unchanged, including Docker)
 - 최소 설치 — essentials only
 - 회사 PC용 — no Docker
 
-The profile is a starting point. A fourth `사용자 지정` state appears when users change the runtime, Docker, or AI-agent component checkboxes.
+The profile is a starting point. A fifth `사용자 지정` state appears when users change the runtime, Docker, or AI-agent component checkboxes.
 
 ### Component selection and permissions
 
@@ -132,6 +133,8 @@ An active run adds a contextual secondary action (`미리보기 취소` or
 while work is active; choosing Quit cancels the complete installer process tree,
 waits for cleanup, and only then terminates the app. Cancellation restores every
 setup control and reports a neutral mode-specific cancellation state.
+
+Successful installation means the installer process exited successfully, not that every tool was verified. The existing selectable log gives concise first-use steps: open a new terminal, run explicit version checks for the selected components, and initialize a project before starting Claude Code or Codex and completing their own authentication. Preview, failure, cancellation, and Terminal handoff do not claim installation or verification. The doctor remains a full inventory; recommended users are directed to explicit versions rather than promised a green doctor. No new controls, visual tokens, or layout are introduced.
 
 ### Version and updates
 

--- a/gui/macos/main.swift
+++ b/gui/macos/main.swift
@@ -10,6 +10,11 @@ private struct InstallerProfile {
 
 private let profilePlans = [
   InstallerProfile(
+    id: "recommended",
+    title: "추천 설치",
+    steps: ["prereqs", "brew", "runtimes", "shell", "git", "agents"]
+  ),
+  InstallerProfile(
     id: "full",
     title: "전체 설치",
     steps: ["prereqs", "brew", "runtimes", "shell", "docker", "git", "agents"]
@@ -236,6 +241,7 @@ private func selfTest() {
     "hasApplicationIcon": true,
     "interfaceVersion": 4,
     "profiles": profiles,
+    "defaultProfile": profilePlans[0].id,
     "profileSteps": profileSteps,
     "supportsAppearanceSnapshots": true,
     "supportsCustomSelection": true,
@@ -1165,6 +1171,32 @@ private final class InstallerController: NSObject, NSApplicationDelegate, NSWind
     }
   }
 
+  private func firstUseGuidance() -> String {
+    let steps = selectedStepIDs()
+    var checks = ["brew --version; git --version; gh --version"]
+    if steps.contains("runtimes") {
+      checks.append("node --version; python3 --version; go version; rustc --version")
+    }
+    if steps.contains("docker") {
+      checks.append("docker --version; colima --version")
+    }
+    if steps.contains("agents") {
+      checks.append("claude --version; codex --version")
+    }
+    var lines = [
+      "",
+      "설치기 종료는 도구 검증이 아닙니다. 오류나 건너뛴 항목은 위 로그를 확인하세요.",
+      "새 터미널을 열고 선택한 도구의 버전을 직접 확인하세요:",
+    ] + checks + [
+      "",
+      "첫 프로젝트: 작업 폴더에서 git init을 실행하세요.",
+    ]
+    if steps.contains("agents") {
+      lines.append("그 폴더에서 claude 또는 codex를 실행하고 도구 자체 로그인 안내를 따르세요.")
+    }
+    return lines.joined(separator: "\n") + "\n"
+  }
+
   private func handleSessionResult(_ result: InstallerProcessResult, dryRun: Bool) {
     if result.cancelled {
       finish(
@@ -1188,14 +1220,14 @@ private final class InstallerController: NSObject, NSApplicationDelegate, NSWind
       message: result.status == 0
         ? (
           dryRun
-            ? "미리보기 완료 · 실제 설치를 시작할 수 있습니다."
-            : "구성 적용 완료 · 새 터미널을 열어 PATH와 프롬프트를 적용하세요."
+            ? "미리보기 완료 · 구성 적용 가능"
+            : "설치기 완료 · 도구 확인 필요"
         )
         : (dryRun
           ? "미리보기가 완료되지 않았습니다. 아래 로그를 확인해 주세요."
           : "설치가 완료되지 않았습니다. 아래 로그를 확인해 주세요."),
       action: action,
-      capturedLog: result.output
+      capturedLog: result.output + (action == .openNewTerminal ? firstUseGuidance() : "")
     )
   }
 
@@ -1265,6 +1297,13 @@ private final class InstallerController: NSObject, NSApplicationDelegate, NSWind
       let environment = BuildInfo.developerMode
         ? ProcessInfo.processInfo.environment
         : [:]
+      if let snapshotPath = environment["STARTER_KIT_GUI_SNAPSHOT"] {
+        do {
+          try renderSnapshot(to: snapshotPath)
+        } catch {
+          appendLog("\nQA snapshot failed: \(error.localizedDescription)\n")
+        }
+      }
       if let resultPath = environment["STARTER_KIT_GUI_RESULT"] {
         do {
           try "\(code)\n\(message)\n\(action.rawValue)\n\(guidance?.rawValue ?? "")\n".write(
@@ -1331,9 +1370,10 @@ private final class InstallerController: NSObject, NSApplicationDelegate, NSWind
     case "ready-success":
       dryRun.state = .off
       logEmptyState.isHidden = true
-      log.stringValue = "qa-selected:--yes --only prereqs,brew,runtimes,shell,docker,git,agents\nqa-final\n"
+      log.stringValue = "qa-selected:--yes --only \(selectedStepIDs().joined(separator: ","))\nqa-final\n"
+        + firstUseGuidance()
       setStatus(
-        "구성 적용 완료 · 새 터미널을 열어 PATH와 프롬프트를 적용하세요.",
+        "설치기 완료 · 도구 확인 필요",
         style: .success
       )
       installButton.title = "구성 다시 적용"

--- a/gui/windows/installer.ps1
+++ b/gui/windows/installer.ps1
@@ -2,7 +2,49 @@
 [CmdletBinding()]
 param([switch]$SelfTest)
 
-$Profiles = @('full', 'minimal', 'work')
+$Profiles = @('recommended', 'full', 'minimal', 'work')
+$DefaultProfileIndex = 0
+$PreviewByDefault = $true
+$ProfileTitles = @('권장 설치', '전체 단계', '최소 설치', '회사 PC용')
+$ProfileDescriptions = @{
+  recommended = '권장: 기본 도구, 런타임, PowerShell, Git, Codex + Claude Code. Docker/WSL 제외.'
+  full = '전체 단계: 권장 구성 + Docker/WSL 단계. GUI는 -Yes로 실행하므로 신규 Docker/WSL 설치는 건너뜁니다. 기존 Ubuntu는 초기화하거나 Linux 설치기를 실행할 수 있습니다. 미리보기 로그를 확인하세요.'
+  minimal = '최소: 기본 도구, 런타임, PowerShell, Git. AI 에이전트와 Docker/WSL 제외.'
+  work = '회사 PC용: 기본 도구, 런타임, PowerShell, Git, Codex + Claude Code. Docker/WSL 제외. 회사 정책을 먼저 확인하세요.'
+}
+$VerificationCommands = @('codex --version', 'claude --version')
+$ProjectCommand = 'codex'
+
+function Get-InstallerSwitches([string]$ProfileName, [bool]$Preview) {
+  $switches = "-Yes -Profile '$ProfileName'"
+  if ($Preview) { $switches += ' -DryRun' }
+  return $switches
+}
+
+function Get-InstallerCompletion([int]$ExitCode, [bool]$Preview, [bool]$Cancelled) {
+  if ($Cancelled) {
+    return @{ State = 'cancelled'; Status = '설치가 취소되었습니다.'; Guidance = '' }
+  }
+  if ($ExitCode -ne 0) {
+    return @{ State = 'failed'; Status = '설치가 완료되지 않았습니다. 아래 로그를 확인해 주세요.'; Guidance = '' }
+  }
+  if ($Preview) {
+    return @{ State = 'preview'; Status = '미리보기가 끝났습니다.'; Guidance = '아직 설치하지 않았습니다. 로그와 선택 범위를 확인한 뒤 실제 설치를 시작하세요.' }
+  }
+  return @{
+    State = 'finished-unverified'
+    Status = '설치 단계가 끝났습니다. 새 PowerShell에서 도구를 확인하세요.'
+    Guidance = @"
+프로세스 종료 코드 0은 모든 도구의 설치/로그인 확인을 뜻하지 않습니다. 경고와 건너뛴 항목을 로그에서 확인하세요.
+1) 새 PowerShell 창을 여세요. 현재 창에는 새 PATH와 프로필이 반영되지 않을 수 있습니다.
+2) AI 에이전트를 선택했다면 다음 명령으로 확인하세요 (최소 설치에는 포함되지 않습니다):
+   $($VerificationCommands -join ([Environment]::NewLine + '   '))
+   실패하면 로그에서 실패한 단계를 확인하고 같은 설치 범위로 다시 실행하세요.
+3) 프로젝트 폴더로 이동: cd path\to\your-project
+   $ProjectCommand 또는 claude를 실행하고 안내에 따라 로그인하세요.
+"@
+  }
+}
 $ReleasesUrl = 'https://github.com/Heoooooon/lazy-starter-kit/releases/latest'
 $CanonicalRepositoryUrl = 'https://github.com/Heoooooon/lazy-starter-kit.git'
 $BundledInstallerPath = Join-Path $PSScriptRoot 'bootstrap-install.ps1'
@@ -54,6 +96,18 @@ if ($SelfTest) {
     installerSource = $InstallerSource
     previewActionTitle = '미리보기 시작'
     profiles = $Profiles
+    defaultProfile = $Profiles[$DefaultProfileIndex]
+    previewByDefault = $PreviewByDefault
+    previewSwitches = Get-InstallerSwitches $Profiles[$DefaultProfileIndex] $true
+    installSwitches = Get-InstallerSwitches $Profiles[$DefaultProfileIndex] $false
+    verificationCommands = $VerificationCommands
+    projectCommand = $ProjectCommand
+    completionStates = @{
+      preview = (Get-InstallerCompletion 0 $true $false).State
+      success = (Get-InstallerCompletion 0 $false $false).State
+      failure = (Get-InstallerCompletion 1 $false $false).State
+      cancelled = (Get-InstallerCompletion 0 $false $true).State
+    }
     releaseRef = $ReleaseRef
     releaseCommit = $ReleaseCommit
     releasesURL = $ReleasesUrl
@@ -93,14 +147,14 @@ $profileLabel.Location = New-Object System.Drawing.Point(31, 109)
 
 $profile = New-Object System.Windows.Forms.ComboBox
 $profile.DropDownStyle = 'DropDownList'
-$null = $profile.Items.AddRange(@('전체 설치', '최소 설치', '회사 PC용'))
-$profile.SelectedIndex = 0
+$null = $profile.Items.AddRange($ProfileTitles)
+$profile.SelectedIndex = $DefaultProfileIndex
 $profile.Location = New-Object System.Drawing.Point(105, 105)
 $profile.Size = New-Object System.Drawing.Size(170, 28)
 
 $dryRun = New-Object System.Windows.Forms.CheckBox
 $dryRun.Text = '설치 전 변경 내용을 미리 보기'
-$dryRun.Checked = $true
+$dryRun.Checked = $PreviewByDefault
 $dryRun.AutoSize = $true
 $dryRun.Location = New-Object System.Drawing.Point(295, 108)
 
@@ -140,18 +194,18 @@ $log = New-Object System.Windows.Forms.TextBox
 $log.Multiline = $true
 $log.ReadOnly = $true
 $log.ScrollBars = 'Vertical'
-$log.WordWrap = $false
+$log.WordWrap = $true
 $log.Font = New-Object System.Drawing.Font('Consolas', 9)
 $log.BackColor = [System.Drawing.Color]::White
 $log.Location = New-Object System.Drawing.Point(31, 180)
 $log.Size = New-Object System.Drawing.Size(694, 395)
 $log.Anchor = 'Top,Bottom,Left,Right'
-$log.Text = @'
-준비가 되었습니다.
-
-처음이라면 '설치 전 변경 내용을 미리 보기'를 켠 채 시작하세요.
-미리보기가 끝나면 체크를 끄고 다시 눌러 실제 설치를 진행할 수 있습니다.
-'@
+function Show-ProfileSelection {
+  $log.Text = $ProfileDescriptions[$Profiles[$profile.SelectedIndex]] + [Environment]::NewLine + [Environment]::NewLine +
+    '처음이라면 미리보기로 변경 내용을 확인하세요. 미리보기가 끝나면 버튼을 다시 눌러 실제 설치할 수 있습니다.'
+}
+Show-ProfileSelection
+$profile.Add_SelectedIndexChanged({ Show-ProfileSelection })
 
 $form.Controls.AddRange(@(
   $title, $subtitle, $profileLabel, $profile, $dryRun,
@@ -255,12 +309,17 @@ $timer.Add_Tick({
     $code = $script:InstallerProcess.ExitCode
     $script:InstallerProcess.Dispose()
     $script:InstallerProcess = $null
-    if ($script:CancelRequested) {
-      $status.Text = '설치가 취소되었습니다.'
+    $completion = Get-InstallerCompletion $code $script:WasDryRun $script:CancelRequested
+    $status.Text = $completion.Status
+    if ($completion.Guidance) {
+      $log.AppendText([Environment]::NewLine + [Environment]::NewLine + $completion.Guidance + [Environment]::NewLine)
+      $log.SelectionStart = $log.TextLength
+      $log.ScrollToCaret()
+    }
+    if ($completion.State -eq 'cancelled') {
       $status.ForeColor = [System.Drawing.Color]::DimGray
       $installButton.Text = if ($dryRun.Checked) { '미리보기 시작' } else { '설치 시작' }
-    } elseif ($code -eq 0) {
-      $status.Text = if ($script:WasDryRun) { '미리보기가 끝났습니다.' } else { '설치가 끝났습니다.' }
+    } elseif ($completion.State -in @('preview', 'finished-unverified')) {
       $status.ForeColor = [System.Drawing.Color]::ForestGreen
       if ($script:WasDryRun) {
         $dryRun.Checked = $false
@@ -269,7 +328,6 @@ $timer.Add_Tick({
         $installButton.Text = '다시 실행'
       }
     } else {
-      $status.Text = '설치가 완료되지 않았습니다. 아래 로그를 확인해 주세요.'
       $status.ForeColor = [System.Drawing.Color]::Firebrick
       $installButton.Text = '다시 실행'
     }
@@ -292,7 +350,7 @@ $installButton.Add_Click({
   $dryRun.Enabled = $false
   $status.Text = '설치 파일을 내려받는 중...'
   $status.ForeColor = [System.Drawing.Color]::DimGray
-  $log.Clear()
+  $log.Text = $ProfileDescriptions[$Profiles[$profile.SelectedIndex]] + [Environment]::NewLine + [Environment]::NewLine
 
   try {
     Remove-InstallerArtifacts
@@ -340,8 +398,7 @@ $installButton.Add_Click({
     $script:WasDryRun = $dryRun.Checked
     $payloadQuoted = $script:InstallerPayload.Replace("'", "''")
     $logQuoted = $script:InstallerLog.Replace("'", "''")
-    $switches = "-Yes -Profile '$profileName'"
-    if ($script:WasDryRun) { $switches += ' -DryRun' }
+    $switches = Get-InstallerSwitches $profileName $script:WasDryRun
     $command =
       "trap { `$_ | Out-File -FilePath '$logQuoted' -Encoding utf8 -Append; exit 1 }; " +
       "& '$payloadQuoted' $switches *>&1 | Out-File -FilePath '$logQuoted' -Encoding utf8; " +

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@
 #   --yes, -y        Non-interactive: accept defaults, never prompt.
 #   --only  a,b,c    Run only these steps.
 #   --skip  a,b,c    Run all steps except these.
-#   --profile NAME   Preset step set: full · minimal · work.
+#   --profile NAME   Preset step set: recommended (no Docker) · full · minimal · work.
 #   --no-agents      Shortcut for --skip agents.
 #   --doctor         Diagnose the install (health report), change nothing, exit.
 #   --update         Git-pull the latest kit, then continue the run.
@@ -226,12 +226,20 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run)   export DRY_RUN=1 ;;
     -y|--yes)    export ASSUME_YES=1 ;;
-    --only)      ONLY="${2:-}"; shift ;;
-    --only=*)    ONLY="${1#*=}" ;;
-    --skip)      SKIP="${2:-}"; shift ;;
-    --skip=*)    SKIP="${1#*=}" ;;
-    --profile)   PROFILE="${2:-}"; shift ;;
-    --profile=*) PROFILE="${1#*=}" ;;
+    --only|--skip|--profile|--only=*|--skip=*|--profile=*)
+      option="${1%%=*}"
+      if [[ "$1" == *=* ]]; then
+        value="${1#*=}"
+      else
+        [[ $# -ge 2 && "${2:-}" != -* ]] || die "$option requires a value"
+        value="$2"; shift
+      fi
+      [[ -n "${value// /}" ]] || die "$option requires a non-empty value"
+      case "$option" in
+        --only) ONLY="$value" ;;
+        --skip) SKIP="$value" ;;
+        --profile) PROFILE="$value" ;;
+      esac ;;
     --no-agents) SKIP="${SKIP:+$SKIP,}agents" ;;
     --doctor)    DOCTOR=1 ;;
     --list)      printf '%s\n' "${STEP_IDS[@]}"; exit 0 ;;
@@ -258,18 +266,19 @@ if [[ -n "$PROFILE" ]]; then
   case "$PROFILE" in
     full)    PRESET_SKIP="" ;;
     minimal) PRESET_SKIP="docker,agents" ;;
-    work)    PRESET_SKIP="docker" ;;
-    *) die "unknown profile: '$PROFILE' (valid: full minimal work)" ;;
+    recommended|work) PRESET_SKIP="docker" ;;
+    *) die "unknown profile: '$PROFILE' (valid: recommended full minimal work)" ;;
   esac
   [[ -n "$PRESET_SKIP" ]] && SKIP="${SKIP:+$SKIP,}$PRESET_SKIP"
 fi
 
 _validate_ids() {
   local list="$1" tok id found valid="${STEP_IDS[*]}"
+  [[ "$list" != ,* && "$list" != *, && "$list" != *,,* ]] \
+    || die "empty step id in selector: '$list'"
   while [[ -n "$list" ]]; do
     tok="${list%%,*}"
     if [[ "$list" == *,* ]]; then list="${list#*,}"; else list=""; fi
-    [[ -z "$tok" ]] && continue
     found=0
     for id in "${STEP_IDS[@]}"; do [[ "$id" == "$tok" ]] && found=1; done
     [[ "$found" == 1 ]] || die "unknown step id: '$tok' (valid: $valid)"
@@ -290,6 +299,7 @@ selected() {
       [[ "$keep" == 1 ]] && echo "$id"
     fi
   done
+  return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -323,6 +333,10 @@ else
   step "Next steps"
   zshrc="$(zsh_config_file .zshrc)"
   info "1) Open a NEW terminal (or: source $(shell_quote "$zshrc")) so PATH + prompt load."
+  if [[ "$KIT_INSTALL_FAILED" == "0" ]] && selected | grep -x agents >/dev/null; then
+    info "Check the agents in that terminal: codex --version and claude --version."
+    info "Then cd into a project you trust and run codex or claude; follow its sign-in prompts."
+  fi
   if command -v gh >/dev/null 2>&1 && ! gh auth status >/dev/null 2>&1; then
     info "2) Sign in to GitHub:  gh auth login   (also sets your git identity)"
   fi

--- a/linux/install.sh
+++ b/linux/install.sh
@@ -13,7 +13,7 @@
 #   --yes, -y        Non-interactive: accept defaults, never prompt.
 #   --only  a,b,c    Run only these steps.
 #   --skip  a,b,c    Run all steps except these.
-#   --profile NAME   Preset step set: full · minimal · work.
+#   --profile NAME   Preset step set: recommended (no Docker) · full · minimal · work.
 #   --no-agents      Shortcut for --skip agents.
 #   --doctor         Diagnose the install (health report), change nothing, exit.
 #   --update         Git-pull the latest kit, then continue the run.
@@ -194,12 +194,20 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run)   export DRY_RUN=1 ;;
     -y|--yes)    export ASSUME_YES=1 ;;
-    --only)      ONLY="${2:-}"; shift ;;
-    --only=*)    ONLY="${1#*=}" ;;
-    --skip)      SKIP="${2:-}"; shift ;;
-    --skip=*)    SKIP="${1#*=}" ;;
-    --profile)   PROFILE="${2:-}"; shift ;;
-    --profile=*) PROFILE="${1#*=}" ;;
+    --only|--skip|--profile|--only=*|--skip=*|--profile=*)
+      option="${1%%=*}"
+      if [[ "$1" == *=* ]]; then
+        value="${1#*=}"
+      else
+        [[ $# -ge 2 && "${2:-}" != -* ]] || die "$option requires a value"
+        value="$2"; shift
+      fi
+      [[ -n "${value// /}" ]] || die "$option requires a non-empty value"
+      case "$option" in
+        --only) ONLY="$value" ;;
+        --skip) SKIP="$value" ;;
+        --profile) PROFILE="$value" ;;
+      esac ;;
     --no-agents) SKIP="${SKIP:+$SKIP,}agents" ;;
     --doctor)    DOCTOR=1 ;;
     --list)      printf '%s\n' "${STEP_IDS[@]}"; exit 0 ;;
@@ -226,18 +234,19 @@ if [[ -n "$PROFILE" ]]; then
   case "$PROFILE" in
     full)    PRESET_SKIP="" ;;
     minimal) PRESET_SKIP="docker,agents" ;;
-    work)    PRESET_SKIP="docker" ;;
-    *) die "unknown profile: '$PROFILE' (valid: full minimal work)" ;;
+    recommended|work) PRESET_SKIP="docker" ;;
+    *) die "unknown profile: '$PROFILE' (valid: recommended full minimal work)" ;;
   esac
   [[ -n "$PRESET_SKIP" ]] && SKIP="${SKIP:+$SKIP,}$PRESET_SKIP"
 fi
 
 _validate_ids() {
   local list="$1" tok id found valid="${STEP_IDS[*]}"
+  [[ "$list" != ,* && "$list" != *, && "$list" != *,,* ]] \
+    || die "empty step id in selector: '$list'"
   while [[ -n "$list" ]]; do
     tok="${list%%,*}"
     if [[ "$list" == *,* ]]; then list="${list#*,}"; else list=""; fi
-    [[ -z "$tok" ]] && continue
     found=0
     for id in "${STEP_IDS[@]}"; do [[ "$id" == "$tok" ]] && found=1; done
     [[ "$found" == 1 ]] || die "unknown step id: '$tok' (valid: $valid)"
@@ -258,6 +267,7 @@ selected() {
       [[ "$keep" == 1 ]] && echo "$id"
     fi
   done
+  return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -288,6 +298,10 @@ else
   step "Next steps"
   zshrc="$(zsh_config_file .zshrc)"
   info "1) Open a NEW terminal (or: source $(shell_quote "$zshrc")) so PATH + prompt load."
+  if selected | grep -x agents >/dev/null; then
+    info "Check the agents in that terminal: codex --version and claude --version."
+    info "Then cd into a project you trust and run codex or claude; follow its sign-in prompts."
+  fi
   if command -v gh >/dev/null 2>&1 && ! gh auth status >/dev/null 2>&1; then
     info "2) Sign in to GitHub:  gh auth login   (also sets your git identity)"
   fi

--- a/tests/install-entrypoints.sh
+++ b/tests/install-entrypoints.sh
@@ -1,22 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
 # shellcheck source=lib/common.sh
 source "$ROOT/lib/common.sh"
-TMP_ROOT="$ROOT/.tmp-tests"
-mkdir -p "$TMP_ROOT"
-TMP="$(mktemp -d "$TMP_ROOT/install-entrypoints.XXXXXX")"
-cleanup() {
-  safe_rm_rf_under "$TMP_ROOT" "$TMP"
-  rmdir "$TMP_ROOT" 2>/dev/null || true
-}
-trap cleanup EXIT
-
 fail() {
   printf 'FAIL %s\n' "$*" >&2
   exit 1
 }
+TMP_ROOT="$ROOT/.tmp-tests"
+[[ ! -L "$TMP_ROOT" ]] || fail 'fixture base must not be a symlink'
+mkdir -p "$TMP_ROOT"
+[[ "$(cd "$TMP_ROOT" && pwd -P)" == "$TMP_ROOT" ]] || fail 'fixture base escapes worktree'
+TMP="$(mktemp -d "$TMP_ROOT/install-entrypoints.XXXXXX")"
+OWNER_TOKEN="entrypoints:$:$RANDOM:$RANDOM"
+readonly ROOT TMP_ROOT TMP OWNER_TOKEN
+printf '%s\n' "$OWNER_TOKEN" > "$TMP/.entrypoints-owner"
+validate_fixture() {
+  [[ "$TMP" == "$TMP_ROOT"/install-entrypoints.* && ! -L "$TMP_ROOT" \
+    && ! -L "$TMP" && -O "$TMP" && -d "$TMP" \
+    && ! -L "$TMP/.entrypoints-owner" && -f "$TMP/.entrypoints-owner" ]] || return 1
+  [[ "$(cd "$TMP" && pwd -P)" == "$TMP" ]] || return 1
+  printf '%s\n' "$OWNER_TOKEN" | cmp -s - "$TMP/.entrypoints-owner"
+}
+cleanup() {
+  local status=$?
+  validate_fixture || { printf 'FAIL refusing unsafe fixture cleanup: %s\n' "$TMP" >&2; return 1; }
+  DRY_RUN=0 safe_rm_rf_under "$TMP_ROOT" "$TMP" || return 1
+  return "$status"
+}
+trap cleanup EXIT
+validate_fixture || fail 'invalid fixture ownership'
+mkdir "$TMP/home" "$TMP/tmp" "$TMP/cache"
+export HOME="$TMP/home" USERPROFILE="$TMP/home" CFFIXED_USER_HOME="$TMP/home"
+export TMPDIR="$TMP/tmp/" XDG_CACHE_HOME="$TMP/cache"
+export CLANG_MODULE_CACHE_PATH="$TMP/cache/clang" SWIFT_MODULECACHE_PATH="$TMP/cache/swift"
+export HOMEBREW_CACHE="$TMP/cache/brew" HOMEBREW_LOGS="$TMP/cache/brew-logs"
+export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ANALYTICS=1
+unset BASH_ENV ENV
+printf 'fixtures: root=%s HOME=%s TMPDIR=%s cache=%s\n' "$TMP" "$HOME" "$TMPDIR" "$XDG_CACHE_HOME"
 
 # shellcheck disable=SC2016
 printf '%s\n' '#!/usr/bin/env bash' \
@@ -206,8 +228,12 @@ iconutil -c iconset "$APP/Contents/Resources/AppIcon.icns" -o "$TMP/AppIcon.icon
 [[ "$(sips -g pixelWidth "$TMP/AppIcon.iconset/icon_16x16.png" | awk '/pixelWidth/ {print $2}')" == "16" ]] \
   || fail "macOS GUI bundle does not contain a native 16 px icon representation"
 self_test="$("$APP/Contents/MacOS/LazyStarterKitInstaller" --self-test)"
-[[ "$self_test" == *'"profiles":["full","minimal","work"]'* ]] \
+[[ "$self_test" == *'"profiles":["recommended","full","minimal","work"]'* ]] \
   || fail "macOS GUI self-test did not expose all supported profiles"
+[[ "$self_test" == *'"defaultProfile":"recommended"'* ]] \
+  || fail "macOS GUI initial profile is not recommended"
+[[ "$self_test" == *'"recommended":["prereqs","brew","runtimes","shell","git","agents"]'* ]] \
+  || fail "macOS GUI recommended profile does not match the installer steps"
 [[ "$self_test" == *'"full":["prereqs","brew","runtimes","shell","docker","git","agents"]'* ]] \
   || fail "macOS GUI full profile does not match the installer steps"
 [[ "$self_test" == *'"minimal":["prereqs","brew","runtimes","shell","git"]'* ]] \
@@ -247,6 +273,10 @@ printf '%s' "$self_test" | grep -Eq '"releaseCommit":"[0-9a-f]{40}"' \
 # controller must still be retained long enough to create the real window.
 WINDOW_READY="$TMP/gui-window-ready.txt"
 open -W -n \
+  --env "HOME=$HOME" --env "USERPROFILE=$USERPROFILE" \
+  --env "CFFIXED_USER_HOME=$CFFIXED_USER_HOME" --env "TMPDIR=$TMPDIR" \
+  --env "XDG_CACHE_HOME=$XDG_CACHE_HOME" --env "HOMEBREW_CACHE=$HOMEBREW_CACHE" \
+  --env "HOMEBREW_NO_AUTO_UPDATE=1" --env "HOMEBREW_NO_ANALYTICS=1" \
   --env "STARTER_KIT_GUI_WINDOW_READY=$WINDOW_READY" \
   "$APP"
 [[ "$(<"$WINDOW_READY")" == "window-ready" ]] \
@@ -272,8 +302,10 @@ STARTER_KIT_GUI_AUTOSTART=1 \
 STARTER_KIT_GUI_EXIT_ON_FINISH=1 \
 STARTER_KIT_GUI_RESULT="$GUI_RESULT" \
 STARTER_KIT_GUI_LOG_RESULT="$GUI_LOG_RESULT" \
+STARTER_KIT_GUI_SNAPSHOT="$TMP/live-preview.png" \
   "$APP/Contents/MacOS/LazyStarterKitInstaller"
 [[ -f "$GUI_RESULT" ]] || fail "macOS GUI did not emit its completion signal"
+[[ -s "$TMP/live-preview.png" ]] || fail "macOS GUI did not capture its live preview window"
 IFS= read -r gui_status < "$GUI_RESULT"
 [[ "$gui_status" == "0" ]] \
   || fail "macOS GUI installer path did not complete successfully"
@@ -282,10 +314,47 @@ gui_action="$(sed -n '3p' "$GUI_RESULT")"
   || fail "macOS GUI preview completion does not offer the installation action"
 grep -qxF "payload-final" "$GUI_LOG_RESULT" \
   || fail "macOS GUI dropped the payload's final log output"
-grep -qxF "payload:--yes --only prereqs,brew,runtimes,shell,docker,git,agents --dry-run" \
+grep -qxF "payload:--yes --only prereqs,brew,runtimes,shell,git,agents --dry-run" \
   "$GUI_LOG_RESULT" \
-  || fail "macOS GUI did not pass the selected full component set"
-printf 'ok   macOS GUI runs a payload through its real controller\n'
+  || fail "macOS GUI did not default to the recommended component set"
+printf 'ok   macOS GUI defaults to recommended through its real controller\n'
+
+# Explicit legacy presets retain their semantic arrays, including full Docker.
+for legacy in full work; do
+  legacy_steps=prereqs,brew,runtimes,shell,git,agents
+  [[ "$legacy" != full ]] || legacy_steps=prereqs,brew,runtimes,shell,docker,git,agents
+  STARTER_KIT_INSTALL_URL="file://$TMP/payload.sh" \
+  STARTER_KIT_INSTALL_SHA256="$PAYLOAD_SHA256" \
+  STARTER_KIT_GUI_PROFILE="$legacy" \
+  STARTER_KIT_GUI_AUTOSTART=1 STARTER_KIT_GUI_EXIT_ON_FINISH=1 \
+  STARTER_KIT_GUI_RESULT="$TMP/$legacy-result" \
+  STARTER_KIT_GUI_LOG_RESULT="$TMP/$legacy-log" \
+    "$APP/Contents/MacOS/LazyStarterKitInstaller"
+  [[ "$(head -n 1 "$TMP/$legacy-result")" == 0 ]] || fail "$legacy preview failed"
+  grep -qxF "payload:--yes --only $legacy_steps --dry-run" "$TMP/$legacy-log" \
+    || fail "$legacy profile changed its selected steps"
+done
+printf 'ok   macOS GUI preserves explicit full and work selections\n'
+
+# A nonzero installer exit is a retry, never successful completion.
+printf '%s\n' '#!/usr/bin/env bash' 'printf "payload-failed\n"' 'exit 42' > "$TMP/failing-payload.sh"
+FAIL_SHA256="$(shasum -a 256 "$TMP/failing-payload.sh" | awk '{print $1}')"
+for preview in 1 0; do
+  STARTER_KIT_INSTALL_URL="file://$TMP/failing-payload.sh" \
+  STARTER_KIT_INSTALL_SHA256="$FAIL_SHA256" \
+  STARTER_KIT_GUI_DRY_RUN="$preview" STARTER_KIT_GUI_ADMIN_STATUS=1 \
+  STARTER_KIT_GUI_PREREQUISITES=ready \
+  STARTER_KIT_GUI_AUTOSTART=1 STARTER_KIT_GUI_EXIT_ON_FINISH=1 \
+  STARTER_KIT_GUI_RESULT="$TMP/failure-$preview-result" \
+  STARTER_KIT_GUI_LOG_RESULT="$TMP/failure-$preview-log" \
+    "$APP/Contents/MacOS/LazyStarterKitInstaller"
+  [[ "$(head -n 1 "$TMP/failure-$preview-result")" == 42 \
+    && "$(sed -n '3p' "$TMP/failure-$preview-result")" == retry ]] \
+    || fail "macOS GUI reported success after an installer failure"
+  grep -qxF payload-failed "$TMP/failure-$preview-log" \
+    || fail "macOS GUI lost failing installer output"
+done
+printf 'ok   macOS GUI preserves nonzero preview and install failures\n'
 
 # Given a payload whose declared digest is wrong, when the GUI prepares it,
 # then execution must stop before any payload code runs.
@@ -363,7 +432,7 @@ IFS= read -r minimal_status < "$MINIMAL_RESULT"
 grep -qxF "payload:--yes --only prereqs,brew,runtimes,shell,git --dry-run" \
   "$MINIMAL_LOG_RESULT" \
   || fail "macOS GUI did not pass the selected minimal component set"
-printf 'ok   macOS GUI passes custom component selections\n'
+printf 'ok   macOS GUI preserves the minimal component selection\n'
 
 # Given a standard user account, when an actual install is requested, then the
 # GUI must explain the administrator requirement before running the payload.
@@ -422,7 +491,7 @@ handoff_guidance="$(sed -n '4p' "$HANDOFF_RESULT")"
   || fail "macOS GUI ran the payload before interactive prerequisites"
 [[ -x "$HANDOFF_COMMAND" ]] \
   || fail "macOS GUI did not create an executable Terminal handoff"
-grep -q -- "--only prereqs,brew,runtimes,shell,docker,git,agents" "$HANDOFF_COMMAND" \
+grep -q -- "--only prereqs,brew,runtimes,shell,git,agents" "$HANDOFF_COMMAND" \
   || fail "Terminal handoff lost the selected component steps"
 if grep -Eqi 'password|sudo[[:space:]]+-S|SUDO_ASKPASS' "$HANDOFF_COMMAND"; then
   fail "Terminal handoff contains credential capture logic"
@@ -433,6 +502,7 @@ printf 'ok   macOS GUI creates a credential-safe Terminal handoff\n'
 # succeeds, then completion must expose the one remaining manual action.
 INSTALL_RESULT="$TMP/gui-install-result.txt"
 INSTALL_MARKER="$TMP/gui-install-payload-ran"
+INSTALL_LOG="$TMP/gui-install-log.txt"
 STARTER_KIT_INSTALL_URL="file://$TMP/payload.sh" \
 STARTER_KIT_INSTALL_SHA256="$PAYLOAD_SHA256" \
 STARTER_KIT_PAYLOAD_MARKER="$INSTALL_MARKER" \
@@ -442,6 +512,7 @@ STARTER_KIT_GUI_DRY_RUN=0 \
 STARTER_KIT_GUI_AUTOSTART=1 \
 STARTER_KIT_GUI_EXIT_ON_FINISH=1 \
 STARTER_KIT_GUI_RESULT="$INSTALL_RESULT" \
+STARTER_KIT_GUI_LOG_RESULT="$INSTALL_LOG" \
   "$APP/Contents/MacOS/LazyStarterKitInstaller"
 IFS= read -r install_status < "$INSTALL_RESULT"
 [[ "$install_status" == "0" ]] \
@@ -451,6 +522,8 @@ install_action="$(sed -n '3p' "$INSTALL_RESULT")"
   || fail "macOS GUI completion did not expose the terminal reload action"
 [[ -f "$INSTALL_MARKER" ]] \
   || fail "macOS GUI did not run the actual installer payload"
+grep -qxF "payload:--yes --only prereqs,brew,runtimes,shell,git,agents" "$INSTALL_LOG" \
+  || fail "actual install did not use recommended steps without preview"
 printf 'ok   macOS GUI exposes the post-install terminal action\n'
 
 # Given an installer process tree that announces it is ready, when the GUI

--- a/tests/profiles.sh
+++ b/tests/profiles.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+# shellcheck source=lib/common.sh
+source "$REPO_ROOT/lib/common.sh"
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+TMP_BASE="$REPO_ROOT/.tmp-tests"
+[[ ! -L "$TMP_BASE" ]] || fail 'fixture base must not be a symlink'
+mkdir -p "$TMP_BASE"
+[[ "$(cd "$TMP_BASE" && pwd -P)" == "$TMP_BASE" && -O "$TMP_BASE" ]] \
+  || fail 'fixture base escapes worktree or is not owned'
+WORK="$(mktemp -d "$TMP_BASE/profiles.XXXXXX")"
+OWNER_TOKEN="profiles:$$:$RANDOM:$RANDOM"
+readonly REPO_ROOT TMP_BASE WORK OWNER_TOKEN
+printf '%s\n' "$OWNER_TOKEN" > "$WORK/.profiles-owner"
+validate_fixture_root() {
+  [[ "$1" == "$WORK" && "$1" == "$TMP_BASE"/profiles.* \
+    && ! -L "$TMP_BASE" && ! -L "$1" && -d "$1" && -O "$1" \
+    && ! -L "$1/.profiles-owner" && -f "$1/.profiles-owner" ]] || return 1
+  [[ "$(cd "$1" && pwd -P)" == "$1" ]] || return 1
+  printf '%s\n' "$OWNER_TOKEN" | cmp -s - "$1/.profiles-owner"
+}
+cleanup() {
+  local status=$?
+  validate_fixture_root "$WORK" || {
+    printf 'FAIL: refusing cleanup: fixture boundary or ownership changed: %s\n' "$WORK" >&2
+    return 1
+  }
+  printf 'cleanup: safe_rm_rf_under "%s" "%s"\n' "$TMP_BASE" "$WORK"
+  DRY_RUN=0 safe_rm_rf_under "$TMP_BASE" "$WORK" || return 1
+  return "$status"
+}
+trap cleanup EXIT
+validate_fixture_root "$WORK" || fail 'invalid fixture ownership'
+for boundary in "$REPO_ROOT" "$TMP_BASE" "${HOME:-/}"; do
+  if validate_fixture_root "$boundary"; then fail "accepted non-fixture boundary: $boundary"; fi
+done
+mkdir "$WORK/runner-home" "$WORK/tmp" "$WORK/cache" "$WORK/bin"
+export HOME="$WORK/runner-home" USERPROFILE="$WORK/runner-home"
+export TMPDIR="$WORK/tmp" TMP="$WORK/tmp" TEMP="$WORK/tmp" XDG_CACHE_HOME="$WORK/cache"
+unset BASH_ENV ENV
+printf 'fixtures: root=%s HOME=%s USERPROFILE=%s TMPDIR=%s cache=%s\n' \
+  "$WORK" "$HOME" "$USERPROFILE" "$TMPDIR" "$XDG_CACHE_HOME"
+
+# Execute byte-identical installer copies with harmless step boundaries. The
+# actual macOS brew step consumes selected() unchanged, rather than a test model.
+for platform in macos linux; do
+  root="$WORK/$platform"
+  mkdir -p "$root/scripts"
+  source_root="$REPO_ROOT"
+  [[ "$platform" != linux ]] || source_root="$REPO_ROOT/linux"
+  cp "$source_root/install.sh" "$root/install.sh"
+  cmp "$source_root/install.sh" "$root/install.sh"
+  cp "$REPO_ROOT/VERSION" "$root/VERSION"
+  cp "$REPO_ROOT/lib/common.sh" "$root/common.sh"
+  printf '%s\n' 'source "$ROOT/common.sh"' > "$root/scripts/lib.sh"
+  # Never load host shell config or Homebrew; no network or auth is performed.
+  cat >> "$root/scripts/lib.sh" <<'SH'
+is_macos() { return 0; }
+is_arm() { return 0; }
+is_linux() { return 0; }
+cache_zsh_config_dir() { :; }
+zsh_config_file() { printf '%s/%s\n' "$HOME" "$1"; }
+load_brew() { :; }
+have() { [[ "$1" == brew ]]; }
+brew() {
+  case "$*" in
+    'update --quiet') return 0 ;;
+    'bundle install --file='*|'bundle check --file='*)
+      printf 'brew %s\n' "${3##*/}" >> "$TRACE"
+      [[ "${FAIL_BREW:-0}" != 1 ]] ;;
+    *) printf 'unexpected brew %s\n' "$*" >> "$TRACE"; return 92 ;;
+  esac
+}
+SH
+  for spec in 01-prereqs 02-packages 03-runtimes 04-shell 05-docker 06-git 07-agents; do
+    id="${spec#*-}"
+    printf 'step_%s() { printf "step %s\\n" >> "$TRACE"; }\n' "$id" "$id" > "$root/scripts/$spec.sh"
+  done
+  if [[ "$platform" == macos ]]; then
+    printf '%s\n' 'printf "step brew\n" >> "$TRACE"' > "$root/scripts/02-brew.sh"
+    cat "$REPO_ROOT/scripts/02-brew.sh" >> "$root/scripts/02-brew.sh"
+    cp "$REPO_ROOT/"Brewfile.* "$root/"
+  fi
+done
+cp "$REPO_ROOT/VERSION" "$WORK/VERSION"
+# Tripwires detect accidental external actions, including during RED runs.
+for command in curl git npm sudo docker gh codex claude; do
+  printf '#!/bin/bash\nprintf "unexpected %s %%s\\n" "$*" >> "$TRACE"\nexit 93\n' "$command" > "$WORK/bin/$command"
+  chmod +x "$WORK/bin/$command"
+done
+# gh auth status is an existing read-only completion probe, not an auth action.
+printf '#!/bin/bash\n[[ "$*" == "auth status" ]] && exit 1\nprintf "unexpected gh %%s\\n" "$*" >> "$TRACE"\nexit 93\n' > "$WORK/bin/gh"
+
+failures=0; cases=0
+run_case() {
+  local platform="$1" label="$2" expected_status="$3" steps="$4" bundles="$5"
+  [[ "$platform" != linux ]] || bundles=""
+  shift 5
+  local case_dir="$WORK/$platform-$label" status=0 id bundle
+  validate_fixture_root "$WORK" || fail 'invalid fixture boundary before entrypoint'
+  mkdir -p "$case_dir/home" "$case_dir/tmp" "$case_dir/cache"
+  : > "$case_dir/trace"
+  env -i HOME="$case_dir/home" USERPROFILE="$case_dir/home" \
+    TMPDIR="$case_dir/tmp" TMP="$case_dir/tmp" TEMP="$case_dir/tmp" \
+    XDG_CACHE_HOME="$case_dir/cache" PATH="$WORK/bin:/usr/bin:/bin" \
+    TRACE="$case_dir/trace" FAIL_BREW="${FAIL_BREW:-0}" \
+    /bin/bash "$WORK/$platform/install.sh" --yes "$@" > "$case_dir/output" 2>&1 || status=$?
+  : > "$case_dir/expected"
+  for id in $steps; do
+    printf 'step %s\n' "$id" >> "$case_dir/expected"
+    if [[ "$id" == brew ]]; then
+      for bundle in $bundles; do printf 'brew Brewfile.%s\n' "$bundle" >> "$case_dir/expected"; done
+    fi
+  done
+  cases=$((cases + 1))
+  if [[ "$status" != "$expected_status" ]] || ! diff -u "$case_dir/expected" "$case_dir/trace"; then
+    printf 'FAIL: %s/%s expected exit %s, got %s; args:' "$platform" "$label" "$expected_status" "$status"
+    printf ' <%s>' "$@"; printf '\n'
+    awk '{print}' "$case_dir/output"
+    failures=$((failures + 1))
+  else
+    printf 'ok: %s/%s exit=%s steps=[%s] Brewfiles=[%s]\n' "$platform" "$label" "$status" "$steps" "$bundles"
+  fi
+  # Output is evidence for manual first-use review, never a prose assertion.
+  if [[ "$label" == recommended || "$label" == minimal || "$label" == brew-failure || "$label" == preview ]]; then
+    printf '%s\n' "--- $platform/$label output ---"
+    awk '{print}' "$case_dir/output"
+  fi
+}
+
+for platform in macos linux; do
+  package=brew; [[ "$platform" != linux ]] || package=packages
+  full="prereqs $package runtimes shell docker git agents"
+  recommended="prereqs $package runtimes shell git agents"
+  minimal="prereqs $package runtimes shell git"
+  run_case "$platform" recommended 0 "$recommended" 'core runtimes' --profile recommended
+  run_case "$platform" recommended-equals 0 "$recommended" 'core runtimes' --profile=recommended
+  run_case "$platform" default 0 "$full" 'core runtimes docker'
+  run_case "$platform" full 0 "$full" 'core runtimes docker' --profile full
+  run_case "$platform" minimal 0 "$minimal" 'core runtimes' --profile minimal
+  run_case "$platform" work 0 "$recommended" 'core runtimes' --profile work
+  run_case "$platform" skip-union 0 "prereqs $package shell git" core --profile recommended --skip 'runtimes, agents'
+  run_case "$platform" skip-first 0 "prereqs $package shell git" core --skip=runtimes,agents --profile=recommended
+  run_case "$platform" no-agents 0 "$minimal" 'core runtimes' --profile recommended --no-agents
+  run_case "$platform" full-skip 0 "$recommended" 'core runtimes' --profile full --skip docker
+  run_case "$platform" only 0 "$package shell" core --only "$package, shell"
+  run_case "$platform" only-runtimes 0 "$package runtimes" 'core runtimes' --only "$package,runtimes"
+  run_case "$platform" only-precedence 0 agents '' --only agents --skip agents
+  run_case "$platform" preview 0 "$recommended" 'core runtimes' --profile recommended --dry-run
+  run_case "$platform" empty-plan 0 '' '' --skip "prereqs,$package,runtimes,shell,docker,git,agents"
+  run_case "$platform" profile-only 1 '' '' --profile recommended --only agents
+  run_case "$platform" only-profile 1 '' '' --only=agents --profile=full
+  run_case "$platform" unknown-profile 1 '' '' --profile unknown
+  run_case "$platform" unknown-only 1 '' '' --only typo
+  run_case "$platform" unknown-skip 1 '' '' --profile full --skip typo
+  for selector in only skip profile; do
+    run_case "$platform" "$selector-missing" 1 '' '' "--$selector"
+    run_case "$platform" "$selector-next-option" 1 '' '' "--$selector" --yes
+    run_case "$platform" "$selector-empty" 1 '' '' "--$selector="
+    run_case "$platform" "$selector-blank" 1 '' '' "--$selector" ' '
+  done
+  for selector in only skip; do
+    run_case "$platform" "$selector-leading-comma" 1 '' '' "--$selector=,agents"
+    run_case "$platform" "$selector-trailing-comma" 1 '' '' "--$selector=agents,"
+    run_case "$platform" "$selector-double-comma" 1 '' '' "--$selector=shell,,agents"
+  done
+  if [[ "$platform" == macos ]]; then
+    FAIL_BREW=1 run_case "$platform" brew-failure 1 "$recommended" 'core runtimes' --profile recommended
+  fi
+done
+[[ "$failures" == 0 ]] || fail "$failures of $cases profile scenarios failed"
+printf 'ok: profile entrypoint contracts (%s scenarios)\n' "$cases"

--- a/tests/windows-install-entrypoints.ps1
+++ b/tests/windows-install-entrypoints.ps1
@@ -2,6 +2,22 @@
 
 $Root = Split-Path -Parent $PSScriptRoot
 
+function Assert-GuiOnboardingContract($Contract) {
+  if (($Contract.profiles -join ',') -ne 'recommended,full,minimal,work' -or
+      $Contract.defaultProfile -ne 'recommended' -or
+      -not $Contract.previewByDefault -or
+      $Contract.previewSwitches -ne "-Yes -Profile 'recommended' -DryRun" -or
+      $Contract.installSwitches -ne "-Yes -Profile 'recommended'" -or
+      ($Contract.verificationCommands -join ',') -ne 'codex --version,claude --version' -or
+      $Contract.projectCommand -ne 'codex' -or
+      $Contract.completionStates.preview -ne 'preview' -or
+      $Contract.completionStates.success -ne 'finished-unverified' -or
+      $Contract.completionStates.failure -ne 'failed' -or
+      $Contract.completionStates.cancelled -ne 'cancelled') {
+    throw "Windows GUI onboarding machine contract failed: $($Contract | ConvertTo-Json -Depth 5 -Compress)"
+  }
+}
+
 $guiInstallerPath = Join-Path $Root 'gui\windows\installer.ps1'
 $guiInstallerBytes = [System.IO.File]::ReadAllBytes($guiInstallerPath)
 if ($guiInstallerBytes.Length -lt 3 -or
@@ -47,7 +63,8 @@ if ($env:OS -ne 'Windows_NT') {
 
   $gui = & $guiInstallerPath -SelfTest | Out-String
   $contract = $gui | ConvertFrom-Json
-  if (($contract.profiles -join ',') -ne 'full,minimal,work' -or
+  Assert-GuiOnboardingContract $contract
+  if (($contract.profiles -join ',') -ne 'recommended,full,minimal,work' -or
       -not $contract.supportsDryRun -or
       -not $contract.supportsCancellation) {
     throw "Windows GUI portable self-test contract failed: $gui"
@@ -261,13 +278,14 @@ $gui = & powershell.exe -NoProfile -ExecutionPolicy Bypass -File `
   $guiInstallerPath -SelfTest | Out-String
 if ($LASTEXITCODE -ne 0) { throw "Windows GUI self-test failed: $gui" }
 $contract = $gui | ConvertFrom-Json
+Assert-GuiOnboardingContract $contract
 $guiSource = Get-Content (Join-Path $Root 'gui\windows\installer.ps1') -Raw
 $bootstrapSource = Get-Content (Join-Path $Root 'windows\install.ps1') -Raw
 if ($bootstrapSource -notmatch
     '(?s)if \(\$Doctor\).+?\$global:LASTEXITCODE\s*=\s*\$code') {
   throw 'Windows bootstrap does not preserve Doctor status through hand-off cleanup'
 }
-if (($contract.profiles -join ',') -ne 'full,minimal,work') {
+if (($contract.profiles -join ',') -ne 'recommended,full,minimal,work') {
   throw "Windows GUI profiles are incomplete: $gui"
 }
 if (-not $contract.supportsDryRun) { throw "Windows GUI does not report dry-run support: $gui" }
@@ -337,6 +355,7 @@ try {
     throw "Packaged Windows GUI self-test failed: $packagedGui"
   }
   $packagedContract = $packagedGui | ConvertFrom-Json
+  Assert-GuiOnboardingContract $packagedContract
   $kitVersion = (Get-Content (Join-Path $Root 'VERSION') -Raw).Trim()
   if ($packagedContract.appVersion -ne $kitVersion) {
     throw "Packaged Windows GUI version is not $kitVersion`: $packagedGui"

--- a/tests/windows-profiles.ps1
+++ b/tests/windows-profiles.ps1
@@ -1,0 +1,165 @@
+#requires -Version 5.1
+$ErrorActionPreference = 'Stop'
+$worktree = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).ProviderPath
+$fixtureBase = Join-Path $worktree '.tmp-tests'
+$fixtureRoot = Join-Path $fixtureBase ('windows-profiles-' + [Guid]::NewGuid().ToString('N'))
+$ownerToken = [Guid]::NewGuid().ToString('N')
+$ownerPath = Join-Path $fixtureRoot '.windows-profiles-owner'
+function Assert-Equal($Actual, $Expected, [string]$Label) {
+  if ($Actual -cne $Expected) { throw "${Label}: expected [$Expected], got [$Actual]" }
+}
+function Assert-FixtureBoundary([string]$Path) {
+  $full = [IO.Path]::GetFullPath($Path)
+  $prefix = $fixtureBase + [IO.Path]::DirectorySeparatorChar
+  if (-not $full.StartsWith($prefix, [StringComparison]::Ordinal)) {
+    throw "Fixture path must be strictly below ${fixtureBase}: $Path"
+  }
+  # Reject links in every existing ancestor before writing any fixture data.
+  $cursor = $full
+  while ($cursor) {
+    if (Test-Path -LiteralPath $cursor) {
+      if (((Get-Item -LiteralPath $cursor -Force).Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "Fixture path crosses a reparse point: $cursor"
+      }
+    }
+    if ($cursor -eq $worktree) { break }
+    $cursor = [IO.Path]::GetDirectoryName($cursor)
+  }
+  if ($cursor -ne $worktree) { throw "Fixture path escapes worktree: $Path" }
+}
+
+
+Assert-FixtureBoundary $fixtureRoot
+if (-not (Test-Path -LiteralPath $fixtureBase)) {
+  New-Item -ItemType Directory -Path $fixtureBase | Out-Null
+}
+New-Item -ItemType Directory -Path $fixtureRoot | Out-Null
+[IO.File]::WriteAllText($ownerPath, $ownerToken)
+$savedEnvironment = @{}
+foreach ($name in @('HOME', 'USERPROFILE', 'APPDATA', 'LOCALAPPDATA', 'TMPDIR', 'TMP', 'TEMP', 'XDG_CACHE_HOME', 'STARTER_KIT_HANDOFF_CHILD')) {
+  $savedEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+}
+$savedHome = $HOME
+try {
+  foreach ($name in @('home', 'temp', 'cache', 'scripts')) {
+    New-Item -ItemType Directory -Path (Join-Path $fixtureRoot $name) | Out-Null
+  }
+  $env:HOME = Join-Path $fixtureRoot 'home'
+  $env:USERPROFILE = $env:HOME
+  Set-Variable -Name HOME -Scope Script -Value $env:HOME -Force
+  $env:APPDATA = Join-Path $env:HOME 'AppData/Roaming'
+  $env:LOCALAPPDATA = Join-Path $env:HOME 'AppData/Local'
+  $env:TMPDIR = Join-Path $fixtureRoot 'temp'
+  $env:TMP = $env:TMPDIR
+  $env:TEMP = $env:TMPDIR
+  $env:XDG_CACHE_HOME = Join-Path $fixtureRoot 'cache'
+  $env:STARTER_KIT_HANDOFF_CHILD = '1'
+  Write-Host "Owned fixture: $fixtureRoot; marker: $ownerPath"
+  Write-Host "HOME/USERPROFILE: $env:HOME; temp: $env:TEMP; cache: $env:XDG_CACHE_HOME"
+
+  # Execute the unmodified entrypoint: parameter binding, registry, selectors,
+  # rendered plan and dispatch. Only OS/install boundaries are replaced.
+  $installer = Join-Path $fixtureRoot 'install.ps1'
+  Copy-Item (Join-Path $worktree 'windows/install.ps1') $installer
+  @'
+function Test-IsWindows { $true }
+function Stop-Kit([string]$Message) { throw $Message }
+function Write-Info([string]$Message) { Write-Output $Message }
+function Write-Step([string]$Message) {}
+function Write-Warn([string]$Message) {}
+function Test-HasCommand([string]$Name) { $false }
+'@ | Set-Content (Join-Path $fixtureRoot 'scripts/lib.ps1') -Encoding UTF8
+  $ids = @('prereqs', 'packages', 'runtimes', 'shell', 'docker', 'git', 'agents', 'wsl')
+  for ($i = 0; $i -lt $ids.Count; $i++) {
+    $id = $ids[$i]
+    $step = 'function Step-' + $id + ' { if (-not $script:DryRun -or -not $script:AssumeYes) { throw "Unsafe fixture invocation" }; "dispatch:' + $id + '" }'
+    $step | Set-Content (Join-Path $fixtureRoot ('scripts/{0:00}-{1}.ps1' -f ($i + 1), $id)) -Encoding UTF8
+  }
+  $full = $ids -join ' '
+  $recommended = 'prereqs packages runtimes shell git agents'
+  $minimal = 'prereqs packages runtimes shell git'
+  $cases = @(
+    @{ Name = 'recommended'; Params = @{ Profile = 'recommended' }; Plan = $recommended },
+    @{ Name = 'default remains full'; Params = @{}; Plan = $full },
+    @{ Name = 'full'; Params = @{ Profile = 'full' }; Plan = $full },
+    @{ Name = 'minimal'; Params = @{ Profile = 'minimal' }; Plan = $minimal },
+    @{ Name = 'work'; Params = @{ Profile = 'work' }; Plan = $recommended },
+    @{ Name = 'recommended skip union'; Params = @{ Profile = 'recommended'; Skip = @('shell,git', 'docker') }; Plan = 'prereqs packages runtimes agents' },
+    @{ Name = 'recommended NoAgents'; Params = @{ Profile = 'recommended'; NoAgents = $true }; Plan = $minimal },
+    @{ Name = 'full skip'; Params = @{ Profile = 'full'; Skip = 'agents,wsl' }; Plan = 'prereqs packages runtimes shell docker git' },
+    @{ Name = 'minimal skip'; Params = @{ Profile = 'minimal'; Skip = 'shell' }; Plan = 'prereqs packages runtimes git' },
+    @{ Name = 'work skip'; Params = @{ Profile = 'work'; Skip = 'agents' }; Plan = $minimal },
+    @{ Name = 'only preserves registry order'; Params = @{ Only = @(' agents, shell ', 'agents') }; Plan = 'shell agents' },
+    @{ Name = 'only takes precedence over skip'; Params = @{ Only = 'agents,shell'; Skip = 'agents'; NoAgents = $true }; Plan = 'shell agents' },
+    @{ Name = 'case insensitive profile'; Params = @{ Profile = 'RECOMMENDED' }; Plan = $recommended },
+    @{ Name = 'skip every step'; Params = @{ Profile = 'recommended'; Skip = $ids }; Plan = '' },
+    @{ Name = 'unknown profile'; Params = @{ Profile = 'recomended' }; Reject = $true },
+    @{ Name = 'unknown only token'; Params = @{ Only = 'shell,typo' }; Reject = $true },
+    @{ Name = 'unknown skip token'; Params = @{ Profile = 'recommended'; Skip = 'typo' }; Reject = $true },
+    @{ Name = 'only still validates skip'; Params = @{ Only = 'shell'; Skip = 'typo' }; Reject = $true }
+  )
+  foreach ($preset in @('recommended', 'full', 'minimal', 'work')) {
+    $cases += @{ Name = "$preset rejects only"; Params = @{ Profile = $preset; Only = 'shell' }; Reject = $true }
+  }
+  $failures = @()
+  foreach ($case in $cases) {
+    try {
+      $params = $case.Params
+      $output = @()
+      $failure = $null
+      try { $output = @(& $installer -DryRun -Yes @params) } catch { $failure = $_ }
+      if ($case.Reject) {
+        if (-not $failure) { throw 'Invalid selector accepted' }
+      } else {
+        if ($failure) { throw $failure }
+        $plans = @($output | Where-Object { $_ -match '^steps: ' })
+        Assert-Equal $plans.Count 1 'one parsed plan'
+        $plan = ($plans[0] -replace '^steps: ', '' -replace '\s+\(profile: [^)]+\)$', '').Trim()
+        Assert-Equal $plan $case.Plan 'selected steps'
+        $dispatched = @($output | Where-Object { $_ -match '^dispatch:' } | ForEach-Object { $_ -replace '^dispatch:', '' })
+        Assert-Equal ($dispatched -join ' ') $case.Plan 'actual dispatch order'
+      }
+      Write-Host "PASS: $($case.Name)"
+    } catch {
+      $failures += "$($case.Name): $($_.Exception.Message)"
+      Write-Host "FAIL: $($failures[-1])"
+    }
+  }
+  if ($failures.Count) { throw ($failures -join [Environment]::NewLine) }
+  Write-Host "PASS: Windows profiles ($($cases.Count) cases)"
+} finally {
+  try {
+    # Cleanup authority comes from this fresh root and its independent token,
+    # never from HOME/USERPROFILE or the machine's temporary-directory setting.
+    . (Join-Path $worktree 'windows/scripts/lib.ps1')
+    Assert-FixtureBoundary $ownerPath
+    Assert-Equal ([IO.File]::ReadAllText($ownerPath)) $ownerToken 'cleanup ownership'
+    # Inspect one directory at a time, rejecting links before descending.
+    $pending = New-Object 'System.Collections.Generic.Stack[string]'
+    $pending.Push($fixtureRoot)
+    while ($pending.Count) {
+      $directory = $pending.Pop()
+      Assert-FixtureBoundary $directory
+      foreach ($item in (Get-ChildItem -LiteralPath $directory -Force)) {
+        Assert-FixtureBoundary $item.FullName
+        if ($item.PSIsContainer) { $pending.Push($item.FullName) }
+      }
+    }
+    if (Test-IsWindows) {
+      $script:DryRun = $false
+      Remove-KitTree -AllowedRoot $fixtureBase -Path $fixtureRoot
+      Assert-Equal (Test-Path -LiteralPath $fixtureRoot) $false 'owned fixture cleanup'
+      Write-Host "Cleaned owned fixture through Remove-KitTree: $fixtureRoot"
+    } else {
+      # The existing helper requires native Windows drive paths. Do not widen
+      # it or substitute another recursive deleter for portable Docker tests.
+      Write-Host "Retained owned fixture: $fixtureRoot (Remove-KitTree requires Windows drive paths)"
+    }
+  } finally {
+    # No cleanup runs after restoring the caller's real environment.
+    foreach ($name in $savedEnvironment.Keys) {
+      [Environment]::SetEnvironmentVariable($name, $savedEnvironment[$name], 'Process')
+    }
+    Set-Variable -Name HOME -Scope Script -Value $savedHome -Force
+  }
+}

--- a/windows/install.ps1
+++ b/windows/install.ps1
@@ -14,7 +14,8 @@
 .PARAMETER Yes
   Non-interactive: accept defaults, never prompt.
 .PARAMETER Profile
-  Preset step selection (full|minimal|work):
+  Preset step selection (recommended|full|minimal|work):
+    recommended  prereqs packages runtimes shell git agents (no docker/wsl).
     full     everything (same as no switch).
     minimal  prereqs packages runtimes shell git (skips docker, agents, wsl).
     work     everything except docker and wsl.
@@ -440,8 +441,9 @@ if ($NoAgents) { $Skip = @($Skip) + 'agents' }
 # ($Profile is bound in $PSBoundParameters, so it survives the -Update
 # re-invoke's param rebuild and the bootstrap hand-off's splat automatically.)
 # ---------------------------------------------------------------------------
-$ProfileNames = @('full', 'minimal', 'work')
+$ProfileNames = @('recommended', 'full', 'minimal', 'work')
 $ProfileSkip  = @{
+  recommended = @('docker', 'wsl')
   full    = @()
   minimal = @('docker', 'agents', 'wsl')
   work    = @('docker', 'wsl')
@@ -498,13 +500,19 @@ Write-Step "Done."
 if ($script:DryRun) {
   Write-Info "That was a dry run -- re-run without -DryRun to apply."
 } else {
+  Write-Info "Installer steps finished; this is not verification that every tool is ready."
   Write-Step "Next steps"
   Write-Info "1) Open a NEW PowerShell window so the profile loads (autosuggestions, prompt)."
+  if ($selected -contains 'agents') {
+    Write-Info "2) In that NEW window, verify:  codex --version  and  claude --version"
+    Write-Info "   If either command fails, review the agents log and re-run:  .\install.ps1 -Only agents"
+    Write-Info "3) Start a project:  cd path\to\your-project  then  codex  or  claude (sign in when prompted)."
+  }
   if ((Test-HasCommand gh)) {
     Invoke-NativeSilently 'gh' @('auth', 'status') | Out-Null
-    if ($LASTEXITCODE -ne 0) { Write-Info "2) Sign in to GitHub:  gh auth login   (also sets your git identity)" }
+    if ($LASTEXITCODE -ne 0) { Write-Info "Sign in to GitHub:  gh auth login   (also sets your git identity)" }
   }
-  Write-Info "3) Set your terminal font to 'JetBrainsMono Nerd Font' (Windows Terminal > Settings > Appearance)."
+  Write-Info "Set your terminal font to 'JetBrainsMono Nerd Font' (Windows Terminal > Settings > Appearance)."
   Write-Info "Note: on Windows PowerShell 5.1, restart it once if PSReadLine was upgraded. PowerShell 7 is smoother."
 
   # --- optional: ask for a GitHub star (opt-in, default No) ---------------


### PR DESCRIPTION
## Summary

- Add a recommended profile on macOS, Linux, and Windows without Docker/WSL, retaining existing full/minimal/work and default CLI plans.
- Default both native GUIs to recommended with preview enabled.
- Explain that installer completion is not tool verification; provide version checks and first-project guidance.
- Reject empty Unix selector values and repair the selection producer's exit status so selected runtime Brewfiles are retained when agents are excluded.
- Add profile regressions and CI coverage while preserving pinning, cancellation, administrator handoff, shell guards, and disabled uninstall.

## Verification

- Unix profile tests cover 77 scenarios, including actual Brewfile selection and malformed selectors.
- Existing Unix agent regression covers 18 scenarios.
- Windows portable PowerShell verification: 22 profile cases, agent regression and entrypoint/GUI machine contracts passed in read-only, network-disabled Docker with container-only tmpfs.
- Main session ran the full macOS entrypoint suite successfully, including universal build and real AppKit execution, recommendation/default and legacy profile arguments, failure/cancellation, integrity refusal, and administrator/Terminal handoff.
- Two independent visual reviews passed the complete 12-image light/dark, standard/minimum initial/preview/install matrix.
- Warning-level lint, syntax and release-signing contracts pass. Current CI supplies native Windows verification; portable Docker is not WinForms interaction proof.

## Safety and scope

Test HOME/USERPROFILE/temp/cache paths are owned worktree fixtures. No real HOME installation, uninstall, or cleanup is performed. The original dirty checkout is preserved.

This is Phase 2 of three sequential PRs. README/landing guidance is Phase 3. No release is published by this PR; existing v0.12.0 artifacts do not acquire untagged features.

Merge only after CI and final ultrabrain approval of the exact revision.
