### PR TITLE
docs(setup): guide recommended installation and first use

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -21,7 +21,7 @@ brew "starship"       # cross-shell prompt
 brew "mise"           # node / python / go (and more) version manager
 brew "uv"             # fast Python package/installer manager
 brew "rustup"         # Rust toolchain manager (stable installed in step 03)
-brew "bun"            # JS runtime + package manager (used for gajae-code)
+brew "bun"            # JS runtime + package manager
 
 # --- containers ----------------------------------------------------------
 brew "colima"         # lightweight container runtime (Docker without Desktop)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+The latest published release remains **v0.12.0**. The changes below are in
+current source only; existing release archives don't include them. `VERSION`
+remains `0.12.0` until a separate release is prepared.
+
+### Added
+- **Recommended profiles across macOS, Linux and Windows** ([PR #22](https://github.com/Heoooooon/lazy-starter-kit/pull/22)).
+  `--profile recommended` / `-Profile recommended` selects prerequisites,
+  core packages, runtimes, shell, Git, Claude Code and Codex. It excludes
+  Docker and, on Windows, WSL. Existing `full`, `minimal` and `work` profiles
+  remain available; the CLI default is still `full`.
+- **Bilingual beginner setup and first-project guidance.** Root READMEs now
+  separate the explicit `main` clone and local recommended installer from
+  release-pinned setup, link the actual macOS and Windows GUI assets, and
+  explain inspection, preview, apply, new-terminal version checks and sign-in.
+  Stable `#recommended-setup` and `#first-project` anchors are provided in both
+  READMEs. The profile and release/source policies are recorded in VERSIONING.md.
+
+### Changed
+- **Supported agents are Claude Code and Codex** ([PR #21](https://github.com/Heoooooon/lazy-starter-kit/pull/21)).
+  Agent installation, doctor inventory and CI no longer require gajae-code
+  (`gjc`) or lazycodex. Existing installations and their configuration are
+  left alone. Hermes remains opt-in on macOS/Linux with `HERMES=1`.
+- **GUIs start with recommended + preview** (PR #22). Completion guidance
+  distinguishes a successful process exit from verified tool availability,
+  asks users to open a new terminal and check selected tools, and explains
+  starting an agent in a project. Doctor remains a full inventory, not a
+  profile-aware check; omitted Docker/Colima can still produce missing results.
+- **Selected macOS runtimes are no longer omitted when agents are excluded**
+  (PR #22, commit `d947feb`). Step selection now returns success even when the
+  final agents step is skipped, so the selected runtime Brewfile stays included.
+  Profile regression coverage checks the selected steps and Brewfile scope
+  across supported platforms.
+
+### Removed
+- **Automatic uninstall** ([PR #6](https://github.com/Heoooooon/lazy-starter-kit/pull/6),
+  commit `344c025`). The macOS, Linux and Windows uninstall
+  entrypoints now stop with an explanation and a nonzero exit without deleting tools
+  or settings. The kit can't reliably infer ownership of existing software.
+  This retirement isn't present in the v0.12.0 release archives.
+
+## [0.12.0] - 2026-08-13
+
+This released snapshot still uses the older agent roster and full default
+profile, and includes automatic uninstall. It doesn't include the current-source
+recommended setup or removal policy described above.
+
+The following notes were previously left under Unreleased, but describe
+behavior already shipped by v0.12.0.
+
 ### Security
 - **Released GUIs and double-click packages execute an authenticated bootstrap.**
   macOS and Windows packages now include the reviewed installer, pin the exact
@@ -19,7 +68,7 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
   installer code runs; stale or locally modified code is never a fallback.
 - **The one-liner installs the newest release tag instead of `main`.** A fresh
   machine now gets a ref that CI verified end-to-end across six platforms,
-  rather than whatever landed on `main` minutes earlier — a push no longer
+  rather than whatever landed on `main` minutes earlier; a push no longer
   reaches new users before it is released. The chosen ref is printed at startup
   (`==> Using v0.9.0`). `STARTER_KIT_BRANCH` still pins an explicit ref and now
   also accepts `main` to opt back into the development branch.
@@ -38,16 +87,15 @@ and the project aims to follow [Semantic Versioning](https://semver.org/).
   installer tree and clean temporary artifacts before quitting.
 - **macOS GUI releases are universal binaries** for Apple Silicon and Intel.
 - **Antigravity CLI is no longer installed by `install.sh`.** It has its own
-  Google account flow and a small free tier, so it joins Grok Build as a
-  documented manual one-liner instead of a kit-managed agent. The agents step
-  now installs exactly one set — Claude Code, gajae-code, codex, lazycodex —
-  plus the opt-in Hermes Agent on macOS/Linux.
+  Google account flow and isn't a kit-managed agent. In this released snapshot,
+  the agents step installs Claude Code, gajae-code, codex and lazycodex,
+  plus opt-in Hermes Agent on macOS/Linux. See Unreleased for the current roster.
 
 ### Removed
 - **`ANTIGRAVITY=1` no longer does anything.** The env var is gone from all
   three platforms and from the [VERSIONING.md](./VERSIONING.md) contract table.
-  Install `agy` with the one-liner in the README instead. Both uninstallers
-  still remove a manually installed `agy`, so teardown is unchanged.
+  This released snapshot still includes the old uninstall behavior for manually
+  installed `agy`; current source has retired automatic uninstall entirely.
 
 ### Fixed
 - **A failed bootstrap refresh no longer installs from a stale checkout in
@@ -406,7 +454,9 @@ and on every push via GitHub Actions.
 - dry-run: `brew`/`runtimes` steps degrade gracefully on a bare machine instead
   of aborting when prerequisite tools aren't installed yet.
 
-[Unreleased]: https://github.com/Heoooooon/lazy-starter-kit/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/Heoooooon/lazy-starter-kit/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/Heoooooon/lazy-starter-kit/compare/v0.11.0...v0.12.0
+[0.11.0]: https://github.com/Heoooooon/lazy-starter-kit/compare/v0.10.7...v0.11.0
 [0.9.0]: https://github.com/Heoooooon/lazy-starter-kit/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/Heoooooon/lazy-starter-kit/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/Heoooooon/lazy-starter-kit/compare/v0.7.0...v0.8.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,9 @@ PRs that add non-core tools to the base will be asked to move them to
   pipeline chains; `Set-StrictMode -Version Latest` must pass, and native
   commands that write stderr are wrapped (`Invoke-NativeSilently`) because
   scripts run with `$ErrorActionPreference = 'Stop'`.
-- **Preview first** — verify with `./install.sh --dry-run` (and `--dry-run` for
-  uninstall).
-- **CI must pass** — lint + macOS dry-run + a real install→uninstall run.
+- **Preview first**: verify with `./install.sh --profile recommended --dry-run`.
+  Automatic uninstall is retired; legacy entrypoints stop without deletion.
+- **CI must pass**: lint, macOS dry-run, and real installation/verification jobs.
 - **Versioning** — user-visible changes bump [`VERSION`](./VERSION) and get a
   note in [`CHANGELOG.md`](./CHANGELOG.md). The flags, step ids, managed-block
   markers, and env vars are a **semver contract** — see
@@ -100,10 +100,12 @@ docker run --rm -v "$PWD":/src ubuntu:24.04 bash -c \
    cp -r /src /kit && cd /kit && bash linux/install.sh --yes --skip docker'
 ```
 
-CI then runs the full install → verify → idempotency → doctor → uninstall cycle
-on macOS, Windows, Ubuntu, Fedora, Arch, and openSUSE Tumbleweed, plus an
-upgrade-path test — the checks above are enough to make a PR worth opening;
-the matrix catches the rest.
+CI runs installation, verification, and doctor on macOS, Ubuntu, Fedora, Arch,
+and openSUSE Tumbleweed. macOS and Ubuntu also repeat the real installation to
+check idempotency, and Linux has an upgrade-path test. Windows runs regressions,
+one real installation, and inline tool/profile verification; that job doesn't
+run `-Doctor` or repeat the real installation. CI doesn't run automatic uninstall.
+The checks above are enough to make a PR worth opening; the matrix catches the rest.
 
 ## Releases (maintainers)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -220,9 +220,12 @@ at 1180 px.
   live installer session.
 - **Proof rail:** unboxed, bordered facts for platform coverage, preservation,
   and CI verification.
-- **Platform actions:** separate macOS, Windows, and Linux destinations. Primary
-  actions point to a release detail page that exposes the resolved version or
-  to platform documentation rather than executing a mutable branch directly.
+- **Platform actions:** separate macOS and Windows GUI ZIP downloads and a Linux
+  setup guide. Show the published version and source/release distinction before
+  the download choices, with a separate release-notes link. When the release
+  predates recommended setup, prominently direct users to the current-source
+  guide instead of presenting the old ZIP as the new configuration. Links never
+  execute installer code directly.
 - **Editorial section:** left-aligned heading paired with asymmetric supporting
   content; avoid generic three-card feature rows.
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,8 @@
 <div align="center">
 
-<img src="./docs/images/lsk-hero.svg" alt="lazy-starter-kit — One line. Ready to build." width="100%" />
+<img src="./docs/images/lsk-hero.svg" alt="lazy-starter-kit. Ready to build." width="100%" />
+
+*This illustration shows an older release's full-profile preview, not an installed or verified current recommended setup. Follow the [current recommended setup](#recommended-setup) below.*
 
 ### Different machines, one starting line.
 
@@ -11,7 +13,7 @@ The fastest way to start AI coding on your own machine.
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Platform](https://img.shields.io/badge/OS-macOS%20·%20Linux%20·%20Windows-000000)](#)
 
-[한국어](./README.md) · **English** · [Changelog](./CHANGELOG.md)
+[한국어](./README.md) · **English** · [Recommended setup](#recommended-setup) · [First project](#first-project) · [Changelog](./CHANGELOG.md)
 
 </div>
 
@@ -25,13 +27,17 @@ Docker, and AI coding agents one by one.
 lazy-starter-kit bootstraps that development environment in one pass and gives
 you a way to verify the result afterwards.
 
-Main components include:
+The current-source recommended setup includes:
 
 - CLI: git, gh, jq, ripgrep, fd, fzf, bat, tree, ast-grep, zoxide
 - Runtimes: Node.js, Python, Go, Rust
-- Shell/prompt: zsh, oh-my-zsh, starship, Nerd Font
-- Containers: Colima on macOS, Docker Engine on Linux, optional Docker Desktop on Windows
-- AI agents: Claude Code, gajae-code, Codex, lazycodex
+- Shell/prompt: zsh and oh-my-zsh on macOS/Linux, PowerShell on Windows, starship, Nerd Font
+- AI agents: Claude Code (`claude`) and Codex (`codex`)
+
+Docker is excluded, as is WSL on Windows. Hermes is opt-in on macOS/Linux
+with `HERMES=1`, not part of the beginner setup; there's no native Windows
+Hermes installer. The current kit neither installs nor deletes retired agents
+such as gajae-code (`gjc`) and lazycodex, or their existing configuration.
 
 Existing tools are left alone where practical, and managed configuration files
 are edited only inside clearly marked blocks. Use `--doctor` to inspect the
@@ -39,106 +45,198 @@ current state and `--dry-run` to preview changes before applying them.
 
 ---
 
-## Install
+<a id="recommended-setup"></a>
+
+## Recommended setup (current source, not yet released)
+
+**Start here if you want Claude Code and Codex without retired agents or
+Docker/WSL.** The latest release is still **v0.12.0**. Its installers include
+the older agent roster (gajae-code and lazycodex), start with the full profile,
+and still include automatic uninstall. They don't provide the current-source
+policy. Release ZIPs are pinned to their release, not updated by changes to
+`main`.
+
+The commands below explicitly clone `main` and run the local installer. This
+opts into unreleased changes; it isn't the release-pinned bootstrap route.
+Install [Git](https://git-scm.com/downloads) first and open a new terminal, or
+download the [main source ZIP](https://github.com/Heoooooon/lazy-starter-kit/archive/refs/heads/main.zip),
+extract it, and open a terminal in `lazy-starter-kit-main`. With the ZIP, skip
+the clone and `cd` commands. Use a new folder rather than an existing checkout.
+
+### 1. Inspect and preview
+
+Open the installer and its `scripts/` folder in an editor before running it.
+Preview prints the selected steps without installing them. Check that `docker`
+and, on Windows, `wsl` are absent from the plan.
 
 ### macOS
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Heoooooon/lazy-starter-kit/main/install.sh | bash
+git clone --branch main --single-branch https://github.com/Heoooooon/lazy-starter-kit.git
+cd lazy-starter-kit
+# Inspect install.sh and scripts/, then preview:
+bash ./install.sh --profile recommended --dry-run
 ```
 
 ### Linux
 
-Supports Ubuntu/Debian, Fedora/RHEL, Arch, and openSUSE families.
+Ubuntu/Debian, Fedora/RHEL, Arch, and openSUSE families:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Heoooooon/lazy-starter-kit/main/linux/install.sh | bash
+git clone --branch main --single-branch https://github.com/Heoooooon/lazy-starter-kit.git
+cd lazy-starter-kit
+# Inspect linux/install.sh and linux/scripts/, then preview:
+bash ./linux/install.sh --profile recommended --dry-run
 ```
 
-Details: [linux/README.md](linux/README.md)
+Platform details: [Linux guide](linux/README.md).
 
 ### Windows
 
-From PowerShell:
+In PowerShell (5.1 or newer):
 
 ```powershell
-irm https://raw.githubusercontent.com/Heoooooon/lazy-starter-kit/main/windows/install.ps1 | iex
-```
-
-Details: [windows/README.md](windows/README.md)
-
-GUI and double-click installers are available from
-[Releases](https://github.com/Heoooooon/lazy-starter-kit/releases).
-
----
-
-## Prefer to inspect it first?
-
-If you do not want to execute a remote script immediately, clone the repository
-and run a dry run first.
-
-```bash
-git clone https://github.com/Heoooooon/lazy-starter-kit.git
+git clone --branch main --single-branch https://github.com/Heoooooon/lazy-starter-kit.git
 cd lazy-starter-kit
-./install.sh --dry-run
+# Inspect windows/install.ps1 and windows/scripts/, then preview:
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\windows\install.ps1 -Profile recommended -DryRun
 ```
 
-Windows:
+`-ExecutionPolicy Bypass` applies only to this child process, not your saved
+PowerShell policy. Company policy can still block execution; don't change it
+to work around IT restrictions. Platform details: [Windows guide](windows/README.md).
 
-```powershell
-git clone https://github.com/Heoooooon/lazy-starter-kit.git
-cd lazy-starter-kit\windows
-.\install.ps1 -DryRun
-```
+### 2. Apply the reviewed plan
+
+Stay in the same source folder and run **only your OS's command**:
+
+| OS | Apply |
+|---|---|
+| macOS | `bash ./install.sh --profile recommended` |
+| Linux | `bash ./linux/install.sh --profile recommended` |
+| Windows | `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\windows\install.ps1 -Profile recommended` |
+
+Approve required system prompts only after reviewing them. macOS may require
+Xcode Command Line Tools and Homebrew setup; follow the prerequisite guidance
+and rerun the same command if asked. Review warnings and skipped steps. A
+successful installer exit isn't proof that every tool is installed or signed in.
+Continue with [a new terminal and your first project](#first-project).
+
+### GUI downloads and the standard release route
+
+These are the **released v0.12.0** packages, not the recommended source changes
+above. **Don't use them if avoiding retired-agent installation is required.**
+
+| OS | Released GUI asset | Open after extracting |
+|---|---|---|
+| macOS 14+, Apple Silicon or Intel | [lazy-starter-kit-macos-gui.zip](https://github.com/Heoooooon/lazy-starter-kit/releases/download/v0.12.0/lazy-starter-kit-macos-gui.zip) | `Lazy Starter Kit Installer.app` |
+| Windows | [lazy-starter-kit-windows-gui.zip](https://github.com/Heoooooon/lazy-starter-kit/releases/download/v0.12.0/lazy-starter-kit-windows-gui.zip) | `Lazy-Starter-Kit-Installer.cmd` |
+| Linux | No GUI package | Use the [source commands above](#recommended-setup) or the [Linux guide](linux/README.md) |
+
+See the [latest release page](https://github.com/Heoooooon/lazy-starter-kit/releases/latest)
+for its version and all assets. The standard remote bootstrap resolves the
+newest release tag by default; packaged GUIs pin their own release commit. Neither
+route supplies untagged changes. The v0.12.0 GUIs start with **full + preview**;
+current-source GUIs start with **recommended + preview**. Review the selected
+components and preview log before turning preview off and applying. After
+installation, open a new terminal and check versions yourself.
+
+For a source checkout pinned to the current release, use
+`git clone --branch v0.12.0 --single-branch https://github.com/Heoooooon/lazy-starter-kit.git lazy-starter-kit-v0.12.0`.
+Inspect it, then run its OS installer with `--profile full --dry-run` or
+`-Profile full -DryRun`; remove only the preview flag to apply that older setup.
+The `recommended` profile isn't available in v0.12.0.
 
 ---
 
 ## Common options
 
-macOS/Linux:
+Current source, from the repository root (replace `./install.sh` with
+`./linux/install.sh` on Linux):
 
 ```bash
-./install.sh --dry-run
+./install.sh --profile recommended --dry-run
 ./install.sh --doctor
-./install.sh --update
+./install.sh --update --profile recommended
 ./install.sh --only agents
 ./install.sh --skip docker
 ./install.sh --profile minimal
 ./install.sh --profile work
 ```
 
-Windows uses PowerShell-style flags such as `-DryRun` and `-Only` instead of
-`--dry-run` and `--only`.
+Windows uses `windows\install.ps1` with PowerShell-style flags such as `-DryRun`
+and `-Only` instead of `--dry-run` and `--only`.
+
+| Profile | Current-source selection |
+|---|---|
+| `recommended` | Core tools, runtimes, shell, Git, Claude Code and Codex. No Docker or Windows WSL. |
+| `full` | All steps, including Docker and Windows WSL. Still the CLI default when no profile is passed. Windows installation prompts and prerequisites still apply. |
+| `minimal` | Core tools, runtimes, shell and Git. No agents, Docker or Windows WSL. |
+| `work` | Same steps as recommended; check your employer's policy before installing. |
+
+Profiles combine with `--skip` / `-Skip`, not `--only` / `-Only`. On a source
+ZIP, `--update` / `-Update` isn't available because it requires a Git checkout.
 
 Install steps are designed to be idempotent: re-running the installer should not
 duplicate its managed configuration blocks.
 
 ---
 
-## Verify after install
+<a id="first-project"></a>
+
+## First project
+
+### 1. Open a new terminal and check versions
+
+Open a **new Terminal window** on macOS/Linux, or a **new PowerShell window** on
+Windows, so the installed PATH and shell configuration load. For recommended:
 
 ```bash
-./install.sh --doctor
+git --version
+node --version
+python --version
+go version
+rustc --version
+codex --version
+claude --version
 ```
 
-`--doctor` reports whether each tool is:
+These commands also work in PowerShell. They check command availability, not
+account access. If one fails, review that install step's log before rerunning
+it from the source folder. For example, use `--only runtimes` or `--only agents`
+on the macOS/Linux installer, or `-Only runtimes` / `-Only agents` on Windows.
+Don't add `--profile` / `-Profile` to an `--only` / `-Only` command.
 
-- installed and available
-- installed but not on PATH
-- missing
+`--doctor` / `-Doctor` is an optional **full inventory**, not a profile-specific
+success check. It reports installed, off-PATH and missing tools. A recommended,
+minimal or work setup can report intentionally omitted Docker/Colima as missing
+and exit 1. You don't need to install those tools just to make doctor green.
 
-You can re-run only the affected step when needed.
+### 2. Start in a project folder
+
+In a folder where you keep projects, choose an unused folder name:
 
 ```bash
-./install.sh --only runtimes
-./install.sh --only agents
+mkdir my-first-project
+cd my-first-project
+git init
+codex
 ```
+
+Run `claude` instead if you prefer Claude Code. Follow that tool's own sign-in
+prompts; installing the kit doesn't create an account or provide API credits.
+If Codex asks to approve the kit's shell-safety hook, review it before approving.
+Try asking: "Create a simple hello-world page and explain how to run it."
+Review proposed file changes and commands before accepting them.
 
 ---
 
 ## Automatic uninstall is not supported
 
-**lazy-starter-kit does not provide automatic uninstall functionality.**
+**Current source doesn't provide automatic uninstall functionality.**
+
+The published v0.12.0 release still has the old removal behavior. Don't use an
+old release uninstaller to clean up an existing machine.
 
 Older versions included uninstall scripts, but that behavior has been retired.
 After installation, the kit cannot reliably determine which tools it installed
@@ -171,7 +269,7 @@ record and enforce ownership of everything it creates.
 - **Config backup**: a `.bak` backup is created before the first managed edit of a file.
 - **Recursive-delete boundaries**: internal cleanup rejects HOME, filesystem root, paths outside the allowed boundary, and symlink traversal.
 - **AI shell guard**: an additional defense layer blocks recursive `rm` calls from Codex and Claude Code hooks.
-- **Release-based install**: after bootstrap, installation code resolves against the newest release tag by default.
+- **Explicit source or release**: a local checkout runs that source; the standard remote bootstrap resolves the newest release tag by default. Release GUIs pin their own commit.
 - **CI**: install and health verification run on macOS, Windows, Ubuntu, Fedora, Arch, and openSUSE.
 
 This project still relies on external supply chains including Homebrew,
@@ -203,7 +301,8 @@ Get-Command python -All
 
 ## Corporate machines
 
-Use the work profile for a lighter setup.
+The current-source `work` profile excludes Docker and Windows WSL. It isn't a
+permission bypass. From the source root (use `./linux/install.sh` on Linux):
 
 ```bash
 ./install.sh --profile work
@@ -212,7 +311,7 @@ Use the work profile for a lighter setup.
 Windows:
 
 ```powershell
-.\install.ps1 -Profile work
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\windows\install.ps1 -Profile work
 ```
 
 Items that cannot be installed because of missing admin rights or company policy
@@ -241,4 +340,4 @@ doctor behavior, upgrade paths, and key safety regressions.
 
 ## License
 
-MIT — [LICENSE](LICENSE)
+MIT. [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <div align="center">
 
-<img src="./docs/images/lsk-hero.svg" alt="lazy-starter-kit — 한 줄이면, 바로 시작." width="100%" />
+<img src="./docs/images/lsk-hero.svg" alt="lazy-starter-kit. 개발 준비, 바로 시작." width="100%" />
+
+*위 그림은 이전 릴리스의 full 구성 미리보기 예시이며, 현재 추천 구성의 설치나 검증 결과가 아닙니다. [현재 추천 설치](#recommended-setup)를 따라 주세요.*
 
 ### 사람마다 다른 출발선을 한 줄로 맞춥니다.
 
@@ -11,7 +13,7 @@ AI 코딩, 내 컴퓨터에서 시작하는 가장 빠른 길.
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Platform](https://img.shields.io/badge/OS-macOS%20·%20Linux%20·%20Windows-000000)](#)
 
-**한국어** · [English](./README.en.md) · [변경 이력](./CHANGELOG.md)
+**한국어** · [English](./README.en.md) · [추천 설치](#recommended-setup) · [첫 프로젝트](#first-project) · [변경 이력](./CHANGELOG.md)
 
 </div>
 
@@ -25,13 +27,17 @@ AI 코딩 에이전트 등을 하나씩 설치해야 합니다.
 lazy-starter-kit은 이 과정을 한 번에 구성하고, 설치가 끝난 뒤 제대로
 동작하는지 확인할 수 있게 만든 개발 환경 부트스트랩입니다.
 
-설치되는 주요 항목:
+현재 소스의 추천 설치에 포함되는 항목:
 
 - CLI: git, gh, jq, ripgrep, fd, fzf, bat, tree, ast-grep, zoxide
 - 런타임: Node.js, Python, Go, Rust
-- 셸/프롬프트: zsh, oh-my-zsh, starship, Nerd Font
-- 컨테이너: macOS Colima, Linux Docker Engine, Windows Docker Desktop(선택)
-- AI 에이전트: Claude Code, gajae-code, Codex, lazycodex
+- 셸/프롬프트: macOS/Linux의 zsh와 oh-my-zsh, Windows의 PowerShell, starship, Nerd Font
+- AI 에이전트: Claude Code (`claude`), Codex (`codex`)
+
+Docker는 제외하며 Windows의 WSL도 설치하지 않습니다. Hermes는 macOS/Linux에서
+`HERMES=1`로 별도 선택하는 도구이며 추천 구성에는 포함되지 않습니다. 네이티브
+Windows 설치기는 없습니다. 현재 키트는 지원이 끝난 gajae-code (`gjc`), lazycodex를
+설치하지 않으며, 기존 도구나 해당 설정을 삭제하지도 않습니다.
 
 이미 있는 도구는 가능한 한 그대로 두고, 관리하는 설정 파일은 표시된
 블록만 수정합니다. 상태 확인은 `--doctor`, 실행 전 확인은 `--dry-run`을
@@ -39,12 +45,36 @@ lazy-starter-kit은 이 과정을 한 번에 구성하고, 설치가 끝난 뒤 
 
 ---
 
-## 설치
+<a id="recommended-setup"></a>
+
+## 추천 설치 (현재 소스, 아직 미출시)
+
+**지원이 끝난 에이전트나 Docker/WSL 없이 Claude Code와 Codex로 시작하려면 이 경로를
+사용하세요.** 최신 릴리스는 아직 **v0.12.0**입니다. 이 릴리스는 이전 에이전트 구성
+(gajae-code, lazycodex 포함)과 full 기본 프로필을 사용하며 자동 제거 기능도 남아
+있습니다. 현재 소스의 정책과 다릅니다. 릴리스 ZIP은 해당 릴리스에 고정되므로
+`main`의 변경 사항이 자동으로 반영되지 않습니다.
+
+아래 명령은 `main`을 명시적으로 clone한 뒤 로컬 설치기를 실행합니다. 미출시 변경을
+사용하는 경로이며 릴리스에 고정된 부트스트랩 경로가 아닙니다.
+먼저 [Git](https://git-scm.com/downloads)을 설치하고 새 터미널을 열어 주세요.
+Git 없이 시작하려면 [main 소스 ZIP](https://github.com/Heoooooon/lazy-starter-kit/archive/refs/heads/main.zip)을
+받아 압축을 풀고 `lazy-starter-kit-main` 폴더에서 터미널을 여세요. ZIP을 사용하면
+아래 clone과 `cd` 명령은 생략합니다. 기존 작업 폴더가 아닌 새 폴더를 사용하세요.
+
+### 1. 내용을 읽고 미리보기
+
+실행 전에 편집기에서 설치기와 해당 `scripts/` 폴더를 확인하세요. 미리보기는
+설치하지 않고 선택한 단계를 보여줍니다. 계획에 `docker`가 없는지, Windows에서는
+`wsl`도 없는지 확인하세요.
 
 ### macOS
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Heoooooon/lazy-starter-kit/main/install.sh | bash
+git clone --branch main --single-branch https://github.com/Heoooooon/lazy-starter-kit.git
+cd lazy-starter-kit
+# install.sh와 scripts/를 읽은 뒤 미리보기:
+bash ./install.sh --profile recommended --dry-run
 ```
 
 ### Linux
@@ -52,91 +82,160 @@ curl -fsSL https://raw.githubusercontent.com/Heoooooon/lazy-starter-kit/main/ins
 Ubuntu/Debian, Fedora/RHEL, Arch, openSUSE 계열을 지원합니다.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Heoooooon/lazy-starter-kit/main/linux/install.sh | bash
+git clone --branch main --single-branch https://github.com/Heoooooon/lazy-starter-kit.git
+cd lazy-starter-kit
+# linux/install.sh와 linux/scripts/를 읽은 뒤 미리보기:
+bash ./linux/install.sh --profile recommended --dry-run
 ```
 
 상세 문서: [linux/README.md](linux/README.md)
 
 ### Windows
 
-PowerShell에서:
+PowerShell 5.1 이상에서:
 
 ```powershell
-irm https://raw.githubusercontent.com/Heoooooon/lazy-starter-kit/main/windows/install.ps1 | iex
-```
-
-상세 문서: [windows/README.md](windows/README.md)
-
-GUI/더블클릭 설치 파일은 [Releases](https://github.com/Heoooooon/lazy-starter-kit/releases)에서 받을 수 있습니다.
-
----
-
-## 먼저 확인하고 싶다면
-
-남의 스크립트를 바로 실행하기 꺼려진다면 clone 후 dry-run을 권장합니다.
-
-```bash
-git clone https://github.com/Heoooooon/lazy-starter-kit.git
+git clone --branch main --single-branch https://github.com/Heoooooon/lazy-starter-kit.git
 cd lazy-starter-kit
-./install.sh --dry-run
+# windows/install.ps1과 windows/scripts/를 읽은 뒤 미리보기:
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\windows\install.ps1 -Profile recommended -DryRun
 ```
 
-Windows:
+`-ExecutionPolicy Bypass`는 이 자식 프로세스에만 적용되며 저장된 PowerShell 정책을
+바꾸지 않습니다. 조직 정책으로 차단될 수 있으므로 IT 제한을 우회하려고 정책을
+변경하지 마세요. 상세 문서: [windows/README.md](windows/README.md)
 
-```powershell
-git clone https://github.com/Heoooooon/lazy-starter-kit.git
-cd lazy-starter-kit\windows
-.\install.ps1 -DryRun
-```
+### 2. 확인한 구성 적용
+
+같은 소스 폴더에서 **사용 중인 OS의 명령 하나만** 실행하세요.
+
+| OS | 적용 명령 |
+|---|---|
+| macOS | `bash ./install.sh --profile recommended` |
+| Linux | `bash ./linux/install.sh --profile recommended` |
+| Windows | `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\windows\install.ps1 -Profile recommended` |
+
+필요한 시스템 승인 창은 내용을 읽고 승인하세요. macOS에서는 Xcode Command Line
+Tools와 Homebrew 준비가 필요할 수 있습니다. 안내에 따라 준비를 마친 뒤 다시
+실행하라는 메시지가 나오면 같은 명령을 실행하세요. 경고와 건너뛴 단계를 확인하세요.
+설치 프로세스의 성공 종료가 모든 도구의 설치나 로그인 확인을 뜻하지는 않습니다.
+[새 터미널을 열고 첫 프로젝트 시작하기](#first-project)로 이어집니다.
+
+### GUI 다운로드와 일반 릴리스 경로
+
+아래는 **출시된 v0.12.0** 패키지이며 위의 추천 소스 변경을 포함하지 않습니다.
+**지원이 끝난 에이전트를 설치하지 않아야 한다면 이 패키지를 사용하지 마세요.**
+
+| OS | 출시된 GUI 파일 | 압축을 푼 뒤 열 파일 |
+|---|---|---|
+| macOS 14+, Apple Silicon 또는 Intel | [lazy-starter-kit-macos-gui.zip](https://github.com/Heoooooon/lazy-starter-kit/releases/download/v0.12.0/lazy-starter-kit-macos-gui.zip) | `Lazy Starter Kit Installer.app` |
+| Windows | [lazy-starter-kit-windows-gui.zip](https://github.com/Heoooooon/lazy-starter-kit/releases/download/v0.12.0/lazy-starter-kit-windows-gui.zip) | `Lazy-Starter-Kit-Installer.cmd` |
+| Linux | GUI 패키지 없음 | [위의 소스 명령](#recommended-setup) 또는 [Linux 안내](linux/README.md) 사용 |
+
+[최신 릴리스 페이지](https://github.com/Heoooooon/lazy-starter-kit/releases/latest)에서
+버전과 전체 파일을 확인할 수 있습니다. 일반 원격 부트스트랩은 기본적으로 최신
+릴리스 태그를 선택하고, 패키지 GUI는 자신의 릴리스 커밋에 고정됩니다. 어느 경로도
+태그가 없는 변경을 제공하지 않습니다. v0.12.0 GUI의 초기 선택은 **full + 미리보기**,
+현재 소스 GUI는 **recommended + 미리보기**입니다. 선택한 구성과 미리보기 로그를
+확인한 뒤 미리보기를 끄고 적용하세요. 설치 후에는 새 터미널에서 직접 버전을 확인하세요.
+
+현재 릴리스에 고정한 소스가 필요하다면
+`git clone --branch v0.12.0 --single-branch https://github.com/Heoooooon/lazy-starter-kit.git lazy-starter-kit-v0.12.0`을
+사용하세요. 내용을 확인한 뒤 해당 OS 설치기에 `--profile full --dry-run` 또는
+`-Profile full -DryRun`을 전달하고, 이전 구성을 적용하려면 미리보기 옵션만 빼세요.
+v0.12.0에는 `recommended` 프로필이 없습니다.
 
 ---
 
 ## 자주 쓰는 옵션
 
-macOS/Linux:
+현재 소스의 저장소 루트에서 실행합니다. Linux에서는 `./install.sh`를
+`./linux/install.sh`로 바꾸세요.
 
 ```bash
-./install.sh --dry-run
+./install.sh --profile recommended --dry-run
 ./install.sh --doctor
-./install.sh --update
+./install.sh --update --profile recommended
 ./install.sh --only agents
 ./install.sh --skip docker
 ./install.sh --profile minimal
 ./install.sh --profile work
 ```
 
-Windows는 `--dry-run` 대신 `-DryRun`, `--only` 대신 `-Only`처럼 PowerShell
-형식을 사용합니다.
+Windows에서는 `windows\install.ps1`에 `--dry-run` 대신 `-DryRun`, `--only`
+대신 `-Only`처럼 PowerShell 형식을 사용합니다.
+
+| 프로필 | 현재 소스의 설치 범위 |
+|---|---|
+| `recommended` | 기본 도구, 런타임, 셸, Git, Claude Code와 Codex. Docker와 Windows WSL 제외. |
+| `full` | Docker와 Windows WSL을 포함한 전체 단계. CLI에서 프로필을 생략하면 여전히 이 범위를 사용합니다. Windows의 설치 확인과 사전 조건은 그대로 적용됩니다. |
+| `minimal` | 기본 도구, 런타임, 셸, Git. 에이전트, Docker, Windows WSL 제외. |
+| `work` | recommended와 같은 단계. 설치 전 회사 정책을 확인하세요. |
+
+프로필은 `--skip` / `-Skip`과 함께 사용할 수 있지만 `--only` / `-Only`와는
+함께 사용할 수 없습니다. `--update` / `-Update`는 Git checkout이 필요하므로
+소스 ZIP에서는 사용할 수 없습니다.
 
 설치 단계는 여러 번 실행해도 같은 관리 블록을 중복 생성하지 않도록
 멱등성을 기준으로 설계되어 있습니다.
 
 ---
 
-## 설치 후 확인
+<a id="first-project"></a>
+
+## 첫 프로젝트
+
+### 1. 새 터미널에서 버전 확인
+
+설치된 PATH와 셸 설정이 반영되도록 macOS/Linux에서는 **새 터미널 창**,
+Windows에서는 **새 PowerShell 창**을 여세요. 추천 구성은 다음 명령으로 확인합니다.
 
 ```bash
-./install.sh --doctor
+git --version
+node --version
+python --version
+go version
+rustc --version
+codex --version
+claude --version
 ```
 
-`--doctor`는 도구별로 다음 상태를 보여줍니다.
+PowerShell에서도 같은 명령을 사용할 수 있습니다. 명령 실행 여부를 확인하는 것이며
+계정 접속 확인은 아닙니다. 실패하면 설치 로그의 해당 단계를 확인한 뒤 소스 폴더에서
+그 단계만 다시 실행하세요. macOS/Linux 설치기의 `--only runtimes`, `--only agents`
+또는 Windows의 `-Only runtimes`, `-Only agents`가 예입니다.
+`--only` / `-Only` 명령에는 `--profile` / `-Profile`을 함께 넣지 마세요.
 
-- 정상 설치됨
-- 설치됐지만 PATH에서 찾지 못함
-- 설치되지 않음
+`--doctor` / `-Doctor`는 선택적으로 실행하는 **전체 도구 목록 점검**이며 프로필별
+성공 판정이 아닙니다. 설치됨, PATH에 없음, 누락 상태를 보여줍니다. recommended,
+minimal, work 구성에서는 의도적으로 제외한 Docker/Colima가 누락으로 표시되어
+종료 코드 1이 나올 수 있습니다. doctor를 통과시키려고 이 도구들을 설치할 필요는 없습니다.
 
-문제가 있는 단계만 다시 실행할 수도 있습니다.
+### 2. 프로젝트 폴더에서 시작
+
+프로젝트를 보관할 위치에서 아직 사용하지 않은 폴더 이름을 고르세요.
 
 ```bash
-./install.sh --only runtimes
-./install.sh --only agents
+mkdir my-first-project
+cd my-first-project
+git init
+codex
 ```
+
+Claude Code를 쓰려면 마지막에 `claude`를 실행하세요. 각 도구의 안내에 따라
+로그인합니다. 키트 설치로 계정이나 API 크레딧이 제공되지는 않습니다.
+Codex가 키트의 셸 안전 훅 승인을 요청하면 내용을 검토한 뒤 승인하세요.
+첫 요청은 "간단한 hello-world 페이지를 만들고 실행 방법을 설명해 줘"처럼
+시작할 수 있습니다. 제안된 파일 변경과 명령은 수락하기 전에 확인하세요.
 
 ---
 
 ## 자동 제거(Uninstall)는 지원하지 않습니다
 
-**lazy-starter-kit은 자동 uninstall 기능을 제공하지 않습니다.**
+**현재 소스는 자동 uninstall 기능을 제공하지 않습니다.**
+
+출시된 v0.12.0에는 이전 제거 동작이 남아 있습니다. 기존 컴퓨터를 정리하려고
+오래된 릴리스의 제거 스크립트를 사용하지 마세요.
 
 이전 버전에는 제거 스크립트가 있었지만 폐기했습니다. 이유는 설치 이후
 시점만 보고는 어떤 도구가 lazy-starter-kit이 새로 설치한 것인지, 사용자가
@@ -168,7 +267,7 @@ oh-my-zsh 등을 사용하고 있었다면 이름이나 경로만 기준으로 �
 - **설정 백업**: 관리 파일을 처음 변경할 때 `.bak` 백업을 만듭니다.
 - **재귀 삭제 경계 검사**: 내부 정리가 필요한 경우 HOME/루트/경계 밖/심볼릭 링크를 거부합니다.
 - **AI shell guard**: Codex/Claude Code의 재귀 `rm` 호출을 차단하는 추가 방어층을 제공합니다.
-- **릴리스 기준 설치**: 부트스트랩 이후 설치 코드는 최신 릴리스 태그를 기준으로 실행됩니다.
+- **소스와 릴리스 구분**: 로컬 checkout은 해당 소스를 실행합니다. 일반 원격 부트스트랩은 최신 릴리스 태그를, 릴리스 GUI는 자신의 커밋을 사용합니다.
 - **CI**: macOS, Windows, Ubuntu, Fedora, Arch, openSUSE에서 설치와 상태 검증을 자동 실행합니다.
 
 이 키트는 Homebrew, npm/bun 패키지, 각 프로젝트의 공식 설치 프로그램 등
@@ -200,7 +299,8 @@ Get-Command python -All
 
 ## 회사 PC
 
-가벼운 설정만 원하면 work profile을 사용할 수 있습니다.
+현재 소스의 `work` 프로필은 Docker와 Windows WSL을 제외하지만 권한 제한을
+우회하지는 않습니다. 소스 루트에서 실행하세요. Linux는 `./linux/install.sh`를 사용합니다.
 
 ```bash
 ./install.sh --profile work
@@ -209,7 +309,7 @@ Get-Command python -All
 Windows:
 
 ```powershell
-.\install.ps1 -Profile work
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\windows\install.ps1 -Profile work
 ```
 
 관리자 권한이나 사내 정책 때문에 설치할 수 없는 항목은 건너뛰거나 안내를
@@ -238,4 +338,4 @@ CI는 셸 문법, shellcheck/PSScriptAnalyzer, 설치, 멱등성, doctor,
 
 ## 라이선스
 
-MIT — [LICENSE](LICENSE)
+MIT. [LICENSE](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,7 +28,7 @@ lazy-starter-kit를 안전하게 써주셔서 고맙습니다. 취약점을 발�
 ## 범위 (Scope)
 
 이 키트는 **여러 업스트림 프로젝트의 공식 설치 스크립트를 내려받아 실행**합니다
-(Homebrew, oh-my-zsh, `get.docker.com`, Hermes, `npx lazycodex` 등).
+(Homebrew, oh-my-zsh, Claude Code, 선택 설치인 `get.docker.com`과 Hermes 등).
 
 - **업스트림 자체의 취약점**(예: Homebrew 설치 스크립트 결함)은 **해당 프로젝트에
   직접** 신고해 주세요 — 우리가 고칠 수 있는 부분이 아닙니다.
@@ -66,7 +66,7 @@ repro steps, and `--dry-run` / `-DryRun` output if possible.
 ## Scope
 
 This kit **downloads and runs official install scripts from upstream projects**
-(Homebrew, oh-my-zsh, `get.docker.com`, Hermes, `npx lazycodex`, …).
+(Homebrew, oh-my-zsh, Claude Code, and opt-in `get.docker.com` and Hermes).
 
 - **Vulnerabilities in those upstreams** should be reported **to those projects** —
   they're outside our control.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,8 +1,26 @@
 # Versioning & stability policy
 
 This project follows [Semantic Versioning](https://semver.org/). This document
-defines **what counts as the public interface** — i.e. what you can script
+defines **what counts as the public interface**, what you can script
 against and pin, and what a version number promises about it.
+
+## Current source versus published releases
+
+The latest published release remains **v0.12.0**. It uses the older agent
+roster, defaults to the full profile, and includes automatic uninstall. The
+recommended profile and retirement policies below are unreleased source changes
+from [PR #6](https://github.com/Heoooooon/lazy-starter-kit/pull/6),
+[PR #21](https://github.com/Heoooooon/lazy-starter-kit/pull/21) and
+[PR #22](https://github.com/Heoooooon/lazy-starter-kit/pull/22). `VERSION` remains
+`0.12.0`; a local `--version` / `-Version` result alone doesn't identify these
+changes. Record the checkout commit when pinning source.
+
+The standard remote bootstrap selects the newest release tag by default.
+Packaged GUIs pin their own release commit, so downloading v0.12.0 again won't
+pick up untagged changes. A local source checkout runs its own files. Use the
+[recommended setup guide](README.en.md#recommended-setup) to explicitly clone
+`main` and preview the local installer before applying. Don't use an older
+release if avoiding retired-agent installation is required.
 
 ## The public interface (semver-covered)
 
@@ -10,17 +28,43 @@ Breaking any of these requires a **major** version bump:
 
 | Surface | Examples |
 |---|---|
-| **CLI flags** | `--only`, `--skip`, `--dry-run`, `--yes`, `--profile`, `--doctor`, `--update`, `--list`, `--version`, `--with-gajae` (Windows: the `-PascalCase` equivalents) |
-| **Step / group ids** | install steps (`prereqs`, `brew`/`packages`, `runtimes`, `shell`, `docker`, `git`, `agents`, `wsl`) and uninstall groups — the values accepted by `--only`/`--skip` |
-| **Profile names** | `full`, `minimal`, `work` |
-| **Managed-block markers** | `# >>> lazy-starter-kit:<tag> >>>` … `# <<< lazy-starter-kit:<tag> <<<` in `${ZDOTDIR-$HOME}/.zshrc`, `${ZDOTDIR-$HOME}/.zprofile`, PowerShell profiles — tools and users may key on these |
-| **Environment variables** | `STARTER_KIT_BRANCH` (pin an explicit ref; unset installs the newest release tag), `STARTER_KIT_COMMIT` (require that ref to resolve to one full 40-character commit SHA), `HERMES=1` (opt in to the Hermes agent, macOS/Linux), `ZDOTDIR` (non-empty absolute Zsh config directory), `ASSUME_YES`/CI non-interactive behavior |
-| **Exit codes** | `0` success / `1` failure; `--doctor` exits `0` when nothing is missing (PATH-only warnings don't fail) and `1` when something is — CI enforces this contract |
+| **CLI flags** | `--only`, `--skip`, `--dry-run`, `--yes`, `--profile`, `--doctor`, `--update`, `--list`, `--version` (Windows: the `-PascalCase` equivalents) |
+| **Step ids** | install steps (`prereqs`, `brew`/`packages`, `runtimes`, `shell`, `docker`, `git`, `agents`, `wsl`); the values accepted by `--only`/`--skip` |
+| **Profile names** | `recommended` (current source), `full`, `minimal`, `work` |
+| **Managed-block markers** | `# >>> lazy-starter-kit:<tag> >>>` … `# <<< lazy-starter-kit:<tag> <<<` in `${ZDOTDIR-$HOME}/.zshrc`, `${ZDOTDIR-$HOME}/.zprofile`, PowerShell profiles; tools and users may key on these |
+| **Environment variables** | `STARTER_KIT_BRANCH` (bootstrap ref; unset selects the newest release tag), `STARTER_KIT_COMMIT` (macOS/Windows bootstrap only: require the ref to resolve to one full 40-character commit SHA), `HERMES=1` (opt in to the Hermes agent, macOS/Linux), `ZDOTDIR` (non-empty absolute Zsh config directory), `ASSUME_YES`/CI non-interactive behavior |
+| **Installer exit codes** | `0` success / `1` failure; `--doctor` / `-Doctor` exits `0` when nothing in its full inventory is missing (PATH-only warnings don't fail) and `1` when something is missing |
 | **Backup behavior** | the one-time `.bak` backup before the first managed edit of a config file |
 
 **Minor** versions may: add tools to the default set, add steps/flags/profiles,
 change log wording, change *which versions* of tools get installed.
 **Patch** versions fix bugs without interface changes.
+
+Linux doesn't enforce `STARTER_KIT_COMMIT`. To pin Linux installation code,
+manually check out a reviewed full commit SHA in a local clone, confirm it with
+`git rev-parse HEAD`, and run that checkout's `linux/install.sh` without
+`--update`. Setting the variable on the Linux bootstrap isn't a commit pin.
+
+## Profile and retirement policy (current source)
+
+- `recommended` selects `prereqs`, `brew` (macOS) or `packages` (Linux/Windows),
+  `runtimes`, `shell`, `git` and `agents`. Docker and Windows WSL are excluded.
+- The CLI default remains `full`, selecting all steps. Both GUIs now start
+  with `recommended` and preview enabled. Selecting a Windows Docker/WSL step
+  doesn't bypass its existing prompts, prerequisites or non-interactive limits.
+- `minimal` excludes agents, Docker and Windows WSL. `work` selects the same
+  steps as `recommended`; neither profile bypasses organization policy.
+- Profiles add their exclusions to `--skip` / `-Skip` and can't be combined
+  with `--only` / `-Only`. Selecting runtimes doesn't select Docker packages.
+- Doctor is a full inventory, not filtered by profile. A no-Docker profile can
+  still report Docker/Colima missing and exit 1. Successful installation isn't
+  automatic verification; use explicit version checks in a new terminal.
+- The agents step supports Claude Code and Codex. Retired gajae-code (`gjc`)
+  and lazycodex aren't installed or deleted, and their existing configuration
+  is preserved. Hermes is opt-in on macOS/Linux, not a default requirement.
+- Automatic uninstall is retired. The old entrypoints stop with a nonzero exit and
+  perform no deletion; uninstall flags and groups are no longer supported.
+  This pre-1.0 breaking change is recorded under Unreleased in the changelog.
 
 ## Not covered (may change in any release)
 
@@ -39,7 +83,7 @@ From `v1.0.0` on, the table above is a hard promise.
 
 | Tier | Platforms | Promise |
 |---|---|---|
-| **Tier 1** | macOS 14+ (Apple Silicon) · Windows Server 2025 (≈ Windows 11) · Ubuntu 24.04 · Fedora (latest) · Arch (latest) · openSUSE Tumbleweed | Full install → verify → uninstall runs in CI **on every commit**, plus idempotency (second install) and upgrade-path (previous tag → main) tests |
+| **Tier 1** | macOS 14+ (Apple Silicon) · Windows Server 2025 (≈ Windows 11) · Ubuntu 24.04 · Fedora (latest) · Arch (latest) · openSUSE Tumbleweed | Install and verify jobs in CI, with platform-specific Docker/WSL exclusions; macOS/Ubuntu idempotency checks, Linux upgrade-path checks, and profile/agent regressions. No automatic uninstall jobs. |
 | **Tier 2** | Windows 10 1809+ / 11 desktop · Debian 12+ · RHEL 9 / Rocky / Alma · openSUSE Leap · WSL2 (Ubuntu) · Intel Macs | Expected to work (same code paths), not automatically tested; regressions fixed with priority when reported |
 | **Unsupported** | Alpine / musl distros · 32-bit systems | Upstream tools (node, ast-grep, bun) don't ship builds |
 

--- a/config/zshrc.block.sh
+++ b/config/zshrc.block.sh
@@ -7,7 +7,7 @@ command -v mise >/dev/null && eval "$(mise activate zsh)"
 [ -d /opt/homebrew/opt/rustup/bin ] && export PATH="/opt/homebrew/opt/rustup/bin:$PATH"
 [ -d /usr/local/opt/rustup/bin ]    && export PATH="/usr/local/opt/rustup/bin:$PATH"
 
-# bun: global packages (e.g. gjc / gajae-code) live in ~/.bun/bin
+# bun: global package executables live in ~/.bun/bin
 export BUN_INSTALL="$HOME/.bun"
 [ -d "$BUN_INSTALL/bin" ] && export PATH="$BUN_INSTALL/bin:$PATH"
 [ -s "$BUN_INSTALL/_bun" ] && source "$BUN_INSTALL/_bun"

--- a/docs/index.html
+++ b/docs/index.html
@@ -913,7 +913,7 @@
         </p>
         <div class="actions">
           <a class="button button-primary" href="#start">무료로 시작</a>
-          <a class="button button-secondary" href="https://github.com/Heoooooon/lazy-starter-kit/releases">릴리스 보기</a>
+          <a class="button button-secondary" href="https://github.com/Heoooooon/lazy-starter-kit/releases/latest">릴리스 노트</a>
         </div>
         <p class="source-note">by CMORE · Powered by lazy-starter-kit</p>
       </div>
@@ -930,25 +930,25 @@
             <img src="https://heoooooon.github.io/lazy-starter-kit/brand/app-icon.svg" width="64" height="64" alt="">
             <div>
               <strong>설치 계획 미리보기</strong>
-              <span>실행 전에 확인하게 될 설치 흐름의 예시입니다.</span>
+              <span>현재 소스 기준 예시이며, 공개 ZIP과는 다릅니다.</span>
             </div>
           </div>
           <div class="setup-choice">
             <div>
-              <b>전체 개발 환경</b>
-              <span>런타임 · 셸 · 컨테이너 · AI 코딩 도구</span>
+              <b>추천 설치 · Docker 제외</b>
+              <span>런타임 · 셸 · Git · Claude Code · Codex</span>
             </div>
-            <div class="choice-status">5 / 7 steps</div>
+            <div class="choice-status">5 / 6 steps</div>
           </div>
-          <progress class="progress" aria-label="설치 계획 예시: 일곱 단계 중 다섯 단계" value="5" max="7">5 / 7</progress>
+          <progress class="progress" aria-label="설치 계획 예시: 여섯 단계 중 다섯 단계" value="5" max="6">5 / 6</progress>
           <div class="terminal">
             <p class="terminal-label">Example plan</p>
-            <p><span class="done">01</span>&nbsp;&nbsp;기존 Git 설정 확인</p>
+            <p><span class="done">01</span>&nbsp;&nbsp;기본 개발 도구 준비</p>
             <p><span class="done">02</span>&nbsp;&nbsp;Node.js · Python · Go 준비</p>
-            <p><span class="done">03</span>&nbsp;&nbsp;셸 환경과 프롬프트 연결</p>
-            <p><span class="working">04</span>&nbsp;&nbsp;Docker와 AI 코딩 도구 확인</p>
+            <p><span class="done">03</span>&nbsp;&nbsp;셸 환경과 Git 설정 연결</p>
+            <p><span class="working">04</span>&nbsp;&nbsp;Claude Code · Codex 준비</p>
             <p>&nbsp;</p>
-            <p>실제 실행에서는 단계별 결과와 로그가 표시됩니다.</p>
+            <p>미리보기는 설치가 아닙니다. 적용 후 직접 확인하세요.</p>
           </div>
         </div>
       </div>
@@ -965,7 +965,7 @@
       </li>
       <li class="proof">
         <strong>6 environments in CI</strong>
-        <span>설치부터 제거까지 자동으로 검증합니다.</span>
+        <span>설치·상태 확인과 주요 회귀 검증을 자동 실행합니다.</span>
       </li>
     </ul>
 
@@ -983,21 +983,21 @@
           <span class="step-number">01</span>
           <div>
             <h3>내 운영체제에서 시작</h3>
-            <p>다운로드한 설치 앱 또는 플랫폼별 안내에서 같은 설치 흐름을 시작합니다.</p>
+            <p>새 추천 구성을 쓰려면 <a href="https://github.com/Heoooooon/lazy-starter-kit/blob/main/README.md#recommended-setup">현재 소스 기준 추천 설치 안내</a>에서 시작하세요. 공개 ZIP은 이전 릴리스입니다.</p>
           </div>
         </article>
         <article class="step">
           <span class="step-number">02</span>
           <div>
             <h3>구성을 고르고 미리보기</h3>
-            <p>전체·최소·회사 PC용 프로필을 고르고, 실제 변경 전에 작업 목록을 확인합니다.</p>
+            <p>현재 소스의 GUI는 추천 설치·미리보기로 시작합니다. Docker와 Windows WSL은 제외됩니다. CLI 기본값은 전체 설치이므로 추천 프로필을 명시하세요.</p>
           </div>
         </article>
         <article class="step">
           <span class="step-number">03</span>
           <div>
-            <h3>설치하고 바로 검증</h3>
-            <p>필요한 도구를 공식 배포처에서 설치하고 버전·경로·설정 상태까지 확인합니다.</p>
+            <h3>설치 후 직접 확인하고 첫 프로젝트로</h3>
+            <p>미리보기 후 실제 설치를 실행하고 로그의 경고를 확인하세요. 새 터미널에서 선택한 도구의 버전을 확인한 뒤, 프로젝트 폴더에서 Git을 초기화하고 Claude Code 또는 Codex를 실행해 로그인하세요. 설치 종료만으로 사용 준비가 검증되지는 않습니다.</p>
           </div>
         </article>
       </div>
@@ -1007,10 +1007,10 @@
       <div class="shell section-grid">
         <div>
           <p class="section-kicker">Safety by design</p>
-          <h2 id="safety-title">빠른 것보다, 되돌릴 수 있는 것이 먼저.</h2>
+          <h2 id="safety-title">빠른 것보다, 기존 환경 보호가 먼저.</h2>
           <p class="section-intro">
             새 컴퓨터뿐 아니라 이미 사용 중인 컴퓨터에서도 실행할 수 있도록
-            보존·검증·복구를 설치 과정의 일부로 만들었습니다.
+            기존 설정 보존과 실행 전 확인을 우선합니다.
           </p>
         </div>
         <div class="safety-list">
@@ -1027,8 +1027,8 @@
             <span>같은 설치를 다시 실행해도 설정 블록이 중복되거나 손상되지 않습니다.</span>
           </div>
           <div class="safety-item">
-            <strong>제거와 수동 복구</strong>
-            <span>키트가 관리하는 설정을 정리하고 백업은 수동 복구용으로 남깁니다. Homebrew·Git 정보·폰트 같은 외부 상태는 유지합니다.</span>
+            <strong>자동 제거 미지원</strong>
+            <span>기존 도구와 키트가 설치한 도구를 확실히 구분할 수 없어 자동 제거는 지원하지 않습니다. 개별 도구의 공식 제거 안내를 따르고, 설정과 백업은 직접 확인하세요.</span>
           </div>
         </div>
       </div>
@@ -1042,8 +1042,9 @@
         </div>
         <div>
           <p class="section-intro">
-            런타임, 셸, 컨테이너, Git, AI 코딩 도구가 서로 맞는 경로와 순서로
-            동작하도록 연결하고 설치 결과를 검증합니다.
+            추천 구성은 런타임, 셸, Git, Claude Code와 Codex를 준비합니다.
+            Docker는 별도 선택이며, Hermes는 macOS·Linux에서 선택 설치합니다.
+            설치 후 새 터미널에서 선택한 도구를 확인하세요. doctor는 추천 구성만이 아닌 전체 도구 목록을 점검합니다.
           </p>
           <ul class="tool-band" aria-label="지원 도구">
             <li>Git</li>
@@ -1054,10 +1055,10 @@
             <li>Go</li>
             <li>Rust</li>
             <li>starship</li>
-            <li>Docker</li>
+            <li>Docker (선택)</li>
             <li>Claude Code</li>
             <li>Codex</li>
-            <li>gajae-code</li>
+            <li>Hermes (macOS·Linux 선택)</li>
           </ul>
         </div>
       </div>
@@ -1085,29 +1086,31 @@
         <p class="section-kicker">Start free</p>
         <h2 id="start-title">오늘, 같은 출발선에서 시작하세요.</h2>
         <p>
-          운영체제를 고르면 최신 공개 릴리스 또는 플랫폼별 설치 안내로 이동합니다.
-          실행 전에 릴리스 내용과 소스 코드를 먼저 확인할 수 있습니다.
+          <strong>주의: 최신 공개 릴리스 v0.12.0은 추천 설치 도입과 레거시 에이전트 설치 중단 이전 버전입니다.</strong>
+          아래 GUI ZIP에는 이 변경이 없습니다. 새 구성을 쓰려면
+          <a href="https://github.com/Heoooooon/lazy-starter-kit/blob/main/README.md#recommended-setup">현재 소스 기준 추천 설치 안내</a>를 따르세요.
+          공개 버전의 변경 내역은 <a href="https://github.com/Heoooooon/lazy-starter-kit/releases/latest">릴리스 노트</a>에서 별도로 확인하세요.
         </p>
         <ul class="download-list" aria-label="운영체제별 시작 방법">
           <li>
-            <a class="download-link" href="https://github.com/Heoooooon/lazy-starter-kit/releases/latest">
+            <a class="download-link" href="https://github.com/Heoooooon/lazy-starter-kit/releases/latest/download/lazy-starter-kit-macos-gui.zip">
               <strong>macOS</strong>
-              <span>버전과 릴리스 내용을 확인한 뒤 GUI 앱을 받습니다.</span>
-              <b>릴리스에서 받기</b>
+              <span>공개 GUI ZIP · 현재 v0.12.0<br>새 추천 구성은 포함되지 않습니다.</span>
+              <b>macOS ZIP 받기</b>
             </a>
           </li>
           <li>
-            <a class="download-link" href="https://github.com/Heoooooon/lazy-starter-kit/releases/latest">
+            <a class="download-link" href="https://github.com/Heoooooon/lazy-starter-kit/releases/latest/download/lazy-starter-kit-windows-gui.zip">
               <strong>Windows</strong>
-              <span>버전과 릴리스 내용을 확인한 뒤 GUI 앱을 받습니다.</span>
-              <b>릴리스에서 받기</b>
+              <span>공개 GUI ZIP · 현재 v0.12.0<br>새 추천 구성은 포함되지 않습니다.</span>
+              <b>Windows ZIP 받기</b>
             </a>
           </li>
           <li>
-            <a class="download-link" href="https://github.com/Heoooooon/lazy-starter-kit/blob/main/linux/README.md">
+            <a class="download-link" href="https://github.com/Heoooooon/lazy-starter-kit/blob/main/README.md#recommended-setup">
               <strong>Linux</strong>
-              <span>배포판별 설치와 Dry Run 안내를 확인합니다.</span>
-              <b>가이드 보기</b>
+              <span>현재 소스에서 추천 구성의 미리보기·설치·확인 순서를 안내합니다.</span>
+              <b>추천 설치 안내</b>
             </a>
           </li>
         </ul>

--- a/linux/README.md
+++ b/linux/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-### One command turns a fresh Linux box into a complete dev environment.
+### Set up a Linux development environment with a preview first.
 
-_Build tools · CLI · runtimes · shell · containers · and AI coding agents — installed and verified._
+_Build tools · CLI · runtimes · shell · Git · Codex and Claude Code. Containers are optional._
 
 **[← Back to repo root](../README.md)** · [macOS kit](../README.md) · [Windows kit](../windows/README.md)
 
@@ -10,32 +10,49 @@ _Build tools · CLI · runtimes · shell · containers · and AI coding agents �
 
 ---
 
-> **🇰🇷 한국어 빠른 시작** — 터미널을 열고 아래 한 줄을 붙여넣고 Enter:
+> **🇰🇷 한국어 빠른 시작**: Git이 설치된 터미널에서 `main` 소스를 새 폴더에
+> 복제하고 추천 구성을 미리 확인하세요. `lazy-starter-kit-source` 폴더가 이미
+> 있다면 다른 작업 폴더에서 시작하세요. 복제에 실패하면 다음 단계로 진행하지 마세요.
 > ```sh
-> curl -fsSL https://raw.githubusercontent.com/Heoooooon/lazy-starter-kit/main/linux/install.sh | bash
+> git clone --branch main --depth 1 https://github.com/Heoooooon/lazy-starter-kit.git lazy-starter-kit-source &&
+>   cd lazy-starter-kit-source/linux &&
+>   ./install.sh --profile recommended --dry-run
 > ```
-> apt·dnf·pacman·zypper를 자동 감지합니다 (glibc 배포판; Alpine/musl 미지원). (한국어 전체 안내: [저장소 메인 README](../README.md#-linux-설치))
+> 로그를 확인한 뒤 같은 터미널에서 아래 명령을 실행하면 Docker 없이 설치합니다:
+> ```sh
+> ./install.sh --profile recommended
+> ```
+> apt·dnf·pacman·zypper를 자동 감지합니다 (glibc 배포판; Alpine/musl 미지원).
+> [한국어 추천 설치 안내](../README.md#recommended-setup)
 
 ## Quick start
 
+With Git available, clone `main` into a fresh directory and preview the
+recommended profile. This uses source, not the latest release (`v0.12.0`).
+Start in a folder without an existing `lazy-starter-kit-source` directory.
+The `&&` chain stops if cloning or changing directories fails:
+
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Heoooooon/lazy-starter-kit/main/linux/install.sh | bash
+git clone --branch main --depth 1 https://github.com/Heoooooon/lazy-starter-kit.git lazy-starter-kit-source &&
+  cd lazy-starter-kit-source/linux &&
+  ./install.sh --profile recommended --dry-run
 ```
 
-Prefer to read before you run (recommended):
+After reviewing the preview, apply from the same terminal and directory:
 
 ```sh
-git clone https://github.com/Heoooooon/lazy-starter-kit.git
-cd lazy-starter-kit/linux
-./install.sh --dry-run     # see exactly what it would do
-./install.sh               # apply
+./install.sh --profile recommended # apply without Docker
 ```
+
+`recommended` selects `prereqs,packages,runtimes,shell,git,agents`.
+The CLI default is still `full` when no profile is specified. `minimal` also
+omits agents; `work` selects the same steps as `recommended`.
 
 **Supported distros** (auto-detected package manager): Debian/Ubuntu (`apt`),
 Fedora/RHEL (`dnf`/`yum`), Arch (`pacman`), openSUSE (`zypper`) — all **glibc**.
 Alpine/musl (`apk`) is **not supported** (upstream node, ast-grep and bun ship
-no musl builds). Ubuntu, Fedora, openSUSE and Arch are all verified
-end-to-end (install → verify → uninstall) in CI on every change.
+no musl builds). CI includes installation and verification jobs for Ubuntu,
+Fedora, openSUSE and Arch. It doesn't run automatic uninstall.
 
 ## What you get
 
@@ -47,7 +64,12 @@ end-to-end (install → verify → uninstall) in CI on every change.
 | **Runtimes** | **mise** → node (LTS), python, go, **ast-grep** · **rustup** → rust + rust-analyzer · **uv** · **bun** |
 | **Containers** | **Docker Engine** + compose/buildx (official `get.docker.com`, opt-in) |
 | **Git/GitHub** | identity (GitHub noreply email), HTTPS credential helper, sane defaults |
-| **AI agents** | **Claude Code** (`claude`), **gajae-code** (`gjc`), **codex**, **lazycodex** (OmO), opt-in **Hermes Agent** (`hermes`, `HERMES=1`). Grok and Antigravity are manual one-liners — see the [main README](../README.en.md#manual-install-grok--antigravity). |
+| **AI agents** | **Claude Code** (`claude`) and **Codex** (`codex`). **Hermes Agent** (`hermes`) is optional, enabled only with `HERMES=1`. |
+
+After installation, open a new terminal and check `codex --version` and
+`claude --version`. Then follow the [first-project guide](../README.en.md#first-project)
+and complete the chosen agent's own sign-in flow. An installer exit code alone
+doesn't verify every tool or authenticate your accounts.
 
 ## Steps & flags
 
@@ -64,10 +86,15 @@ prereqs  packages  runtimes  shell  docker  git  agents
 ./install.sh --skip agents         # run all but one
 ./install.sh --no-agents           # alias for --skip agents
 ./install.sh --list                # print step ids
-./install.sh --doctor              # health report: ok / missing / off-PATH per tool
+./install.sh --doctor              # full inventory, not a profile-specific check
 ./install.sh --update              # pull the latest kit, then re-run
-./install.sh --profile work        # presets: full · minimal · work (corporate PCs)
+./install.sh --profile recommended # no Docker; full remains the CLI default
+./install.sh --profile work        # corporate PCs; same steps as recommended
 ```
+
+Doctor checks its full tool/config inventory regardless of the selected profile.
+Tools you intentionally skipped can be reported missing; don't install them just
+to make the report green. Use explicit version checks for the tools you selected.
 
 Every step is **idempotent** — safe to re-run. `${ZDOTDIR-$HOME}/.zshrc` is edited via clearly
 marked managed blocks (`# >>> lazy-starter-kit:* >>>`) that get replaced (never
@@ -75,7 +102,7 @@ duplicated) on re-runs. Existing files you own are preserved.
 
 The agents step also installs a Codex/Claude Code `PreToolUse` guard that blocks
 recursive `rm` and provides `lazy-safe-rm` for strict descendants of the current
-Git workspace. Recursive installer/uninstaller cleanup independently validates
+Git workspace. Recursive installer cleanup independently validates
 physical containment and refuses root, HOME, boundary, outside, and symlink targets.
 
 ## Design notes
@@ -96,23 +123,13 @@ physical containment and refuses root, HOME, boundary, outside, and symlink targ
   installs docker-ce + compose + buildx and adds you to the `docker` group
   (effective after re-login).
 
-## Uninstall
+## Automatic uninstall is not supported
 
-```sh
-./uninstall.sh --dry-run     # preview the teardown
-./uninstall.sh               # run it (destructive groups are confirm-gated)
-./uninstall.sh --yes         # non-interactive, accept every removal
-./uninstall.sh --only agents # remove just one group
-```
-
-Groups (reverse order): `agents shell docker runtimes packages`.
-
-Safe by design:
-- **Never auto-removed**: your **git identity**, and the compiler/build tools.
-- **gajae-code (`gjc`) is kept** unless you pass `--with-gajae`.
-- Removing codex backs up `~/.codex/auth.json` first; `--keep-codex-home` leaves
-  `~/.codex` intact.
-- Only the kit's own managed blocks are stripped from `${ZDOTDIR-$HOME}/.zshrc`.
+The current source doesn't provide automatic uninstall. The legacy
+`linux/uninstall.sh` entrypoint stops with an explanation and exit code 2,
+without changing or removing anything. The kit can't reliably distinguish tools
+it installed from tools you already had. For individual removals, follow the
+tool's official instructions and review your shell configuration manually.
 
 ## Troubleshooting
 

--- a/linux/config/zshrc.block.sh
+++ b/linux/config/zshrc.block.sh
@@ -10,7 +10,7 @@ command -v mise >/dev/null && eval "$(mise activate zsh)"
 [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
 [ -d "$HOME/.cargo/bin" ] && export PATH="$HOME/.cargo/bin:$PATH"
 
-# bun: global packages (e.g. gjc / gajae-code) live in ~/.bun/bin
+# bun: global package executables live in ~/.bun/bin
 export BUN_INSTALL="$HOME/.bun"
 [ -d "$BUN_INSTALL/bin" ] && export PATH="$BUN_INSTALL/bin:$PATH"
 [ -s "$BUN_INSTALL/_bun" ] && source "$BUN_INSTALL/_bun"

--- a/windows/README.md
+++ b/windows/README.md
@@ -2,7 +2,7 @@
 
 ### One command turns a fresh Windows PC into a complete dev environment.
 
-_winget packages · runtimes · PowerShell profile · containers · and AI coding agents — installed and verified._
+_winget packages · runtimes · PowerShell profile · Git · Codex and Claude Code. Docker and WSL are optional._
 
 **[← Back to repo root](../README.md)** · [macOS kit](../README.md) · [Linux kit](../linux/README.md)
 
@@ -10,11 +10,9 @@ _winget packages · runtimes · PowerShell profile · containers · and AI codin
 
 ---
 
-> **🇰🇷 한국어 빠른 시작** — 시작 버튼에서 `PowerShell`을 찾아 열고, 아래 한 줄을 붙여넣고 Enter:
-> ```powershell
-> irm https://raw.githubusercontent.com/Heoooooon/lazy-starter-kit/main/windows/install.ps1 | iex
-> ```
-> 끝나면 PowerShell을 새로 여세요. 막히면 앞에 `powershell -ExecutionPolicy Bypass -Command "..."`로 감싸 실행. (한국어 전체 안내: [저장소 메인 README](../README.md#-windows-설치-제일-자세히))
+> **🇰🇷 한국어 빠른 시작**: 아래 소스 설치 예제에서 `-Profile recommended -DryRun`으로
+> 먼저 확인하고, `-DryRun`을 빼고 설치하세요. 추천 구성은 Docker와 WSL을 제외합니다.
+> 설치가 끝나면 PowerShell을 새로 여세요. [한국어 추천 설치 안내](../README.md#recommended-setup)
 
 ## Quick start
 
@@ -23,29 +21,47 @@ _winget packages · runtimes · PowerShell profile · containers · and AI codin
 - [Download the guided GUI installer](https://github.com/Heoooooon/lazy-starter-kit/releases/latest/download/lazy-starter-kit-windows-gui.zip)
 - [Download the small double-click launcher](https://github.com/Heoooooon/lazy-starter-kit/releases/latest/download/lazy-starter-kit-windows-double-click.zip)
 
-Extract the ZIP and double-click the included `.cmd` file. The GUI offers the
-same full/minimal/work profiles and dry-run preview as the PowerShell installer.
-Both downloads run this repository's `install.ps1`; they do not maintain a
-second installation implementation.
+The latest release is **v0.12.0**. These ZIPs contain that release's launchers,
+not the untagged source changes described below. Extract the ZIP and double-click
+the included `.cmd` file. Release launchers use their pinned release, not mutable
+`main`; don't assume they include the current source's recommended profile or
+preview defaults.
 
-Open **PowerShell** (Windows PowerShell 5.1 or PowerShell 7) and run:
+### Current source: recommended setup
 
-```powershell
-irm https://raw.githubusercontent.com/Heoooooon/lazy-starter-kit/main/windows/install.ps1 | iex
-```
+The source GUI (`gui/windows/installer.ps1`) starts with **recommended** and
+**preview on**. It runs the shared PowerShell installer with `-Yes`.
+`recommended` excludes Docker and WSL. Choosing `full` adds those steps, but
+`-Yes` skips **new Docker Desktop and WSL/Ubuntu installations**. Existing Ubuntu
+can still be initialized or receive the Linux kit as root. Review the preview
+log before applying that profile.
 
-Prefer to read before you run (recommended):
+For a local source copy, open **PowerShell** (Windows PowerShell 5.1 or PowerShell
+7). If Git is already available:
 
 ```powershell
 git clone https://github.com/Heoooooon/lazy-starter-kit.git
 cd lazy-starter-kit\windows
-.\install.ps1 -DryRun     # see exactly what it would do
-.\install.ps1             # apply
+.\install.ps1 -Profile recommended -DryRun # preview
+.\install.ps1 -Profile recommended         # apply without Docker or WSL
 ```
 
-> If scripts are blocked, the installer sets `RemoteSigned` for the current user
-> itself. To run the local copy before that, start it with:
-> `powershell -ExecutionPolicy Bypass -File .\install.ps1`
+Without Git, [download the main source ZIP](https://github.com/Heoooooon/lazy-starter-kit/archive/refs/heads/main.zip),
+extract it, and open PowerShell in its `windows` folder. Run the same preview
+and apply commands above. This source archive is different from a release
+launcher ZIP.
+
+These source commands use `main`, not the latest release ZIP. The recommended
+steps are `prereqs,packages,runtimes,shell,git,agents`. With no profile switch, the
+CLI still selects `full`.
+
+> If scripts are blocked, try a process-scoped bypass for the local preview:
+> `powershell -ExecutionPolicy Bypass -File .\install.ps1 -Profile recommended -DryRun`
+> Organization policy may still block execution; ask your administrator if so.
+> After reviewing the plan, remove only `-DryRun` to apply. During installation,
+> the prerequisites step tries to set CurrentUser `RemoteSigned` for Restricted
+> or Undefined policies and asks before changing AllSigned. Adjustment can fail;
+> it doesn't guarantee that future scripts will run.
 
 **Requirements**: Windows 10 (1809+) or Windows 11 with **winget** (App Installer).
 If `winget` is missing, install *App Installer* from the Microsoft Store first.
@@ -54,13 +70,18 @@ If `winget` is missing, install *App Installer* from the Microsoft Store first.
 
 | Layer | Tools |
 |---|---|
-| **Base** | winget (App Installer), TLS 1.2, `RemoteSigned` execution policy (CurrentUser) |
+| **Base** | winget (App Installer), TLS 1.2, conditional CurrentUser execution-policy adjustment |
 | **CLI** | git, gh, jq, ripgrep, fd, bat, fzf (`tree`/`curl` are built into Windows) |
 | **Shell** | PowerShell profile with **starship** prompt · **PSReadLine 2.2+** inline autosuggestions + list predictions (the `zsh-autosuggestions` equivalent) · **CompletionPredictor** (command-based predictions) · Tab completion menu + history-substring search on ↑/↓ · **PSFzf** (Ctrl-T/Ctrl-R) · JetBrainsMono Nerd Font |
 | **Runtimes** | **mise** → node (LTS), python, go, **ast-grep** · **rustup** → rust + rust-analyzer · **uv** · **bun** |
 | **Containers** | **Docker Desktop** (optional; needs WSL2/virtualization) |
 | **Git/GitHub** | identity (GitHub noreply email), HTTPS credential helper, `core.autocrlf`, sane defaults |
-| **AI agents** | **Claude Code** (`claude`), **gajae-code** (`gjc`), **codex**, **lazycodex** (OmO). Hermes Agent runs inside WSL2; Grok and Antigravity are manual one-liners — see the [main README](../README.en.md#manual-install-grok--antigravity). |
+| **AI agents** | **Claude Code** (`claude`) and **Codex** (`codex`). Hermes is a separate opt-in inside WSL2, not a native Windows installation. |
+
+Open a new PowerShell window after installation and check `codex --version` and
+`claude --version`. Follow the [first-project guide](../README.en.md#first-project)
+and sign in through your chosen agent. An installer exit code alone doesn't
+verify every tool or authenticate your accounts.
 
 ## Steps & flags
 
@@ -76,19 +97,28 @@ prereqs  packages  runtimes  shell  docker  git  agents  wsl
 .\install.ps1 -Only packages,shell  # run a subset
 .\install.ps1 -Skip agents          # run all but one
 .\install.ps1 -NoAgents             # alias for -Skip agents
+.\install.ps1 -Profile recommended  # core tools + agents, without Docker/WSL
 .\install.ps1 -Profile full         # preset: everything (same as no switch)
 .\install.ps1 -Profile minimal      # preset: prereqs packages runtimes shell git (no docker/agents/wsl)
 .\install.ps1 -Profile work         # preset: everything except docker + wsl
 .\install.ps1 -List                 # print step ids
 .\install.ps1 -Version              # print the kit version
-.\install.ps1 -Doctor               # health report: ok / missing / off-PATH per tool
+.\install.ps1 -Doctor               # full inventory, not a profile-specific check
 .\install.ps1 -Update               # pull the latest kit, then re-run
 ```
 
-Every step is **idempotent** — safe to re-run. Your PowerShell profile
+Doctor checks its full tool/config inventory regardless of the selected profile.
+Tools you intentionally skipped can be reported missing; don't install them just
+to make the report green. Use explicit version checks for your selected tools.
+
+Every step is **idempotent**, safe to re-run. Your PowerShell profile
 (`$PROFILE.CurrentUserAllHosts`) is edited via a clearly marked managed block
 (`# >>> lazy-starter-kit:main >>>`) that gets replaced (never duplicated) on
 re-runs. Existing files you own are preserved.
+
+The agents step installs the Codex/Claude Code recursive-`rm` guard.
+`lazy-safe-rm.cmd` delegates guarded workspace cleanup to Git Bash, installed
+with Git for Windows. Review and approve the hook when Codex first asks.
 
 ## Design notes
 
@@ -96,9 +126,10 @@ re-runs. Existing files you own are preserved.
   **mise** (node/python/go/ast-grep) and **rustup** (rust) so versions are easy
   to switch. `ast-grep` is installed via mise's `ubi` backend to match the
   macOS/Linux kits.
-- **No admin required** for the default flow — everything installs per-user.
-  Docker Desktop is the exception (needs virtualization + a reboot) and is
-  strictly opt-in: it defaults to **No**, is **never** installed under `-Yes` or
+- **Permissions depend on the package and machine policy.** Some winget packages
+  may need administrator approval. Docker Desktop needs virtualization and may
+  need a reboot. It is strictly opt-in: it defaults to **No**, is **never**
+  installed under `-Yes` or
   non-interactively (licensing), and must be confirmed with an explicit `y` in an
   interactive run (e.g. `.\install.ps1 -Only docker`).
 - **PATH refresh.** winget puts new tools on the persistent PATH; the installer
@@ -107,49 +138,38 @@ re-runs. Existing files you own are preserved.
 - **Runtimes shadow, never replace.** node/python/go from another source
   (system MSI, nvm-windows, scoop) are left alone; mise's win on PATH. Verify
   with `Get-Command node -All`.
-- **Hermes Agent** has no native Windows build — install it inside a WSL2 distro:
+- **Hermes Agent** has no native Windows build. If you want it, install it inside
+  an existing WSL2 distro:
   `wsl bash -c 'curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --skip-setup'`
-  The `wsl` step below does this for you (it runs the Linux kit inside Ubuntu,
-  and Hermes lands there via that kit).
+  The `wsl` step doesn't enable Hermes. The Linux kit only installs it when
+  `HERMES=1` is explicitly set in its Linux environment.
 
 ## WSL2 + Ubuntu (the `wsl` step)
 
-> ✅ **Validated on real hardware** (v0.6.0): the full pipeline — engine
-> install → reboot → Ubuntu registration → root init → the Linux kit running
-> inside → idempotent re-run — was exercised end-to-end on a fresh Windows 11
-> machine, on top of the parse checks and simulated state-machine tests. If
-> anything misbehaves, please open an issue with the output.
-
 The final step can stand up a full Linux environment on Windows and then run the
-**lazy-starter-kit Linux installer inside it** — so `claude`, `codex`, mise,
-starship, and **Hermes Agent** (no native Windows build) all land inside Ubuntu.
+**lazy-starter-kit Linux installer inside it**, including `claude`, `codex`, mise,
+and starship. Hermes remains opt-in and isn't enabled by this step.
 
-It's an **idempotent, resumable pipeline**: each run detects the current WSL
-state and **advances as far as it can in one go** — it loops detect→act and
-falls straight through registration → root init → the Linux-kit offer in a
-**single run** whenever no reboot is pending. It **never reboots your machine
-for you**.
+Each run detects whether WSL is usable and Ubuntu is registered and runnable:
 
-1. **Detect** — is WSL usable? is WSL2 the default? is `Ubuntu` registered and
-   initialized (can it run `wsl -d Ubuntu -u root -e true`)?
-2. **Not installed** → **opt-in, exactly like Docker Desktop**: it defaults to
-   **No**, is **never** installed under `-Yes` or non-interactively, and needs an
-   **administrator** PowerShell. On an explicit `y` it runs
-   `wsl --install --no-launch -d Ubuntu`. If Windows reports a reboot is needed,
-   it prints a big **REBOOT REQUIRED** next-step — reboot, then re-run.
-3. **Installed but Ubuntu not initialized** → initializes it non-interactively as
-   root (`ubuntu install --root`, which skips the first-run username prompt).
-4. **Ready** → offers (default **Yes** — this is the point of the step) to run the
-   Linux kit inside Ubuntu as root, skipping its docker step; output is streamed
-   live. Failure here is non-fatal. Set `$env:STARTER_KIT_BRANCH` to pin a branch.
+1. **New WSL/Ubuntu installation** needs an administrator PowerShell and explicit
+   interactive consent (default **No**). `-Yes` and redirected input skip it.
+2. **Registered Ubuntu, not initialized** can be initialized as root through
+   `ubuntu install --root`. If the launcher isn't available, the step opens
+   interactive setup or prints first-run guidance.
+3. **Ready Ubuntu** gets an offer to run the Linux kit as root, skipping Docker.
+   That offer defaults to **Yes**, including under `-Yes`. Output is streamed;
+   Linux-kit failure is non-fatal. The bootstrap is downloaded from `main` unless
+   `$env:STARTER_KIT_BRANCH` selects another ref. That bootstrap resolves its own
+   checkout ref, so running Windows source doesn't guarantee the same source
+   revision inside Ubuntu.
 
-Only a **required reboot** stops the pipeline mid-flight; every stage that
-doesn't need one runs in the same invocation. So once WSL is usable, a single
-run registers Ubuntu, initializes it, and offers the Linux kit without asking
-you to re-run in between.
+The pipeline stops for a required reboot, a declined installation, an error, or
+lack of progress. Existing registered Ubuntu can be initialized and offered the
+Linux kit in one run; registering a new distro still requires interactive consent.
 
 ```powershell
-.\install.ps1 -Only wsl            # run just this step (interactive; asks first)
+.\install.ps1 -Only wsl            # new installs ask; existing Ubuntu may be initialized
 .\install.ps1 -Only wsl -DryRun    # print the staged plan for your current state
 ```
 
@@ -157,46 +177,30 @@ The **reboot-resume flow**: `wsl --install` may require a reboot. This step neve
 reboots you; it tells you to reboot and re-run `.\install.ps1 -Only wsl`, and the
 next run picks up from wherever it left off (initialize → run the Linux kit).
 
-> A default full run **includes** `wsl`, but it self-gates: under `-Yes` /
-> non-interactive it just prints a skip line (WSL can't be installed
-> unattended, and CI can't do nested virtualization). Use `-Only wsl` to run it
-> explicitly, or `-Skip wsl` to leave it out.
+> A default full CLI run **includes** `wsl`; recommended does not. Under `-Yes`
+> or redirected input, only **new installation/registration** is skipped.
+> Existing Ubuntu can still be initialized, and the Linux-kit offer defaults to
+> Yes. Use `-Profile recommended` or `-Skip wsl` to leave the entire step out.
 
-## Uninstall
+## Automatic uninstall is not supported
 
-```powershell
-.\uninstall.ps1 -DryRun     # preview the teardown
-.\uninstall.ps1             # run it (destructive groups are confirm-gated)
-.\uninstall.ps1 -Yes        # non-interactive, accept every removal
-.\uninstall.ps1 -Only agents
-```
-
-Groups (reverse order): `wsl agents shell docker runtimes packages`.
-
-Safe by design:
-- **WSL distro is never auto-removed**: the `wsl` group offers
-  `wsl --unregister Ubuntu` behind a **default-No** prompt with an explicit
-  **data-loss** warning (unregister permanently deletes the whole distro
-  filesystem). It's **never** run under `-Yes`. **WSL itself stays installed** —
-  only the Ubuntu distro is offered for removal.
-- **Never auto-removed**: your **git identity**, `git` itself, and the Nerd Font.
-- **gajae-code (`gjc`) is kept** unless you pass `-WithGajae` (refused while running).
-- Removing codex backs up `~/.codex/auth.json` first; `-KeepCodexHome` leaves it intact.
-- Recursive cleanup is centralized in `Remove-KitTree`: it requires a strict
-  descendant of an explicit root and rejects drive roots, `USERPROFILE`, outside
-  paths, dot segments, and junction/reparse-point traversal before deletion.
-- The agents step installs the same Codex/Claude Code recursive-`rm` hook used by
-  the macOS/Linux kits. `lazy-safe-rm.cmd` delegates guarded workspace cleanup to
-  Git Bash, which is installed with Git for Windows.
-- Only the kit's own managed block is stripped from your PowerShell profile.
+The current source doesn't provide automatic uninstall. The legacy
+`windows/uninstall.ps1` entrypoint stops with an explanation and exit code 2,
+without changing or removing anything. The kit can't reliably distinguish tools
+it installed from tools you already had. For individual removals, follow the
+tool's official instructions and review your PowerShell profile manually.
 
 ## Troubleshooting
 
 - **`winget` not recognized** — install *App Installer* from the Microsoft Store
   ([link](https://apps.microsoft.com/detail/9nblggh4nns1)), then reopen PowerShell.
-- **"running scripts is disabled on this system"** — run the local copy with
-  `powershell -ExecutionPolicy Bypass -File .\install.ps1` (the installer then sets
-  `RemoteSigned` for your user so it won't recur).
+- **"running scripts is disabled on this system"**: preview the local copy with
+  `powershell -ExecutionPolicy Bypass -File .\install.ps1 -Profile recommended -DryRun`.
+  Review the plan, then remove only `-DryRun` to apply the same profile. The bypass
+  is process-scoped, but organization policy may still block it. Installation
+  only tries to set CurrentUser `RemoteSigned` for Restricted or Undefined
+  policies; changing AllSigned needs consent. Policy adjustment can fail, so
+  contact your administrator if scripts remain blocked.
 - **Autosuggestions don't appear** — you're likely on Windows PowerShell 5.1 with
   the old PSReadLine still loaded. Restart PowerShell once, or use **PowerShell 7**
   (`winget install Microsoft.PowerShell`) + **Windows Terminal**.

--- a/windows/config/profile.block.ps1
+++ b/windows/config/profile.block.ps1
@@ -9,7 +9,7 @@ if (Get-Command mise -ErrorAction SilentlyContinue) {
   (& mise activate pwsh) -join "`n" | Invoke-Expression
 }
 
-# bun: global packages (e.g. gjc / gajae-code) live in ~/.bun/bin
+# bun: global package executables live in ~/.bun/bin
 $env:BUN_INSTALL = Join-Path $env:USERPROFILE '.bun'
 if (Test-Path (Join-Path $env:BUN_INSTALL 'bin')) {
   $env:Path = (Join-Path $env:BUN_INSTALL 'bin') + ';' + $env:Path


### PR DESCRIPTION
## Summary

- Lead Korean/English setup guidance with current-source recommended installation, preview/apply steps, selected-tool checks and a first project.
- Separate current source from published v0.12.0. Existing release ZIPs still contain the old roster and are not presented as the new setup.
- Provide distinct macOS/Windows GUI downloads and separate release notes, with a prominent current-source guide.
- Align platform, security, contribution and version documentation with disabled automatic uninstall, optional Hermes, actual Windows/WSL behavior, commit-pin platform limits and CI coverage.
- Remove retired-agent examples from comments without changing runtime behavior.

## Verification

- Main-session local Markdown link/fragment checks:57 passed.
- Both GUI download endpoints:HTTP200.
- Real Aside browser QA at375/768/1280px: no horizontal overflow or broken images; real start CTA scroll and release-notes navigation exercised.
-20 overlapping viewport captures cover the whole page. Two independent visual reviewers passed every final capture.
- Bash/Ruby/PowerShell syntax checks and whitespace checks pass. Existing reduced-motion CSS !important lint warnings are unchanged.
- No prose-pinning tests were introduced. Installer behavior was verified in preceding merged PR21/22; this PR changes copy, links and comments only.

## Scope and safety

Final Phase of the sequential setup improvement. Existing HOME and dirty original checkout remain untouched. No release tag, ZIP publication, deploy, credential action, or installation is performed by this PR.

Final ultrabrain approval of the exact revision is required before merge.
